### PR TITLE
Add support to selectors

### DIFF
--- a/examples/react-todo/src/components/NewTodoForm.tsx
+++ b/examples/react-todo/src/components/NewTodoForm.tsx
@@ -1,10 +1,9 @@
 import React, { SyntheticEvent } from "react"
 
+import { add } from "../store/useTodos"
 import useNewTodo from "../store/useNewTodo"
-import useTodos from "../store/useTodos"
 
 export default function NewTodoForm() {
-  const { add } = useTodos()
   const { input } = useNewTodo()
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()

--- a/examples/react-todo/src/components/Summary.tsx
+++ b/examples/react-todo/src/components/Summary.tsx
@@ -1,12 +1,20 @@
 import React from "react"
+import { useArbor } from "@arborjs/react"
 
-import useTodos from "../store/useTodos"
+import { isTodoCompleted, store } from "../store/useTodos"
 
 export default function Summary() {
-  const { todos } = useTodos()
+  const total = useArbor(store, (todos) => todos.length)
+  const completed = useArbor(
+    store,
+    (todos) => todos.filter(isTodoCompleted).length
+  )
+
   return (
     <div className="summary">
-      <small>{todos.length} todos</small>
+      <small>
+        {completed} of {total} completed
+      </small>
     </div>
   )
 }

--- a/examples/react-todo/src/components/TodoView.tsx
+++ b/examples/react-todo/src/components/TodoView.tsx
@@ -1,5 +1,5 @@
 import classnames from "classnames"
-import React, { ChangeEvent } from "react"
+import React, { ChangeEvent, memo } from "react"
 
 import { isTodoCompleted, Todo } from "../store/useTodos"
 
@@ -8,7 +8,7 @@ export interface TodoProps {
   onRemove: () => void
 }
 
-export default function TodoView({ todo, onRemove }: TodoProps) {
+export default memo(function TodoView({ todo, onRemove }: TodoProps) {
   const completed = isTodoCompleted(todo)
   const handleToggleTodo = (e: ChangeEvent<HTMLInputElement>) => {
     todo.status = e.target.checked ? "completed" : "incompleted"
@@ -28,4 +28,4 @@ export default function TodoView({ todo, onRemove }: TodoProps) {
       </button>
     </div>
   )
-}
+})

--- a/examples/react-todo/src/store/useTodos.ts
+++ b/examples/react-todo/src/store/useTodos.ts
@@ -15,18 +15,18 @@ export const store = new Arbor<Todo[]>([])
 
 export const isTodoCompleted = (todo: Todo) => todo.status === "completed"
 
+export const add = ({ text }: TodoData) => {
+  store.root.push({
+    id: uuid(),
+    text,
+    status: "incompleted",
+  })
+}
+
 export default function useTodos() {
   const todos = useArbor(store)
-  const add = ({ text }: TodoData) => {
-    todos.push({
-      id: uuid(),
-      text,
-      status: "incompleted",
-    })
-  }
 
   return {
-    add,
     todos,
   }
 }

--- a/packages/arbor-react/src/useArbor.test.ts
+++ b/packages/arbor-react/src/useArbor.test.ts
@@ -26,6 +26,33 @@ describe("useArbor", () => {
     expect(result.current.count).toBe(5)
   })
 
+  it("subscribes to changes to a specific tree node", () => {
+    const store = new Arbor<{ name: string }[]>([
+      { name: "Bob" },
+      { name: "Alice" },
+    ])
+
+    const user1 = store.root[0]
+    const user2 = store.root[1]
+
+    const { result } = renderHook(() => useArbor(store, (users) => users[1]))
+
+    expect(result.current).toBe(user2)
+
+    act(() => {
+      user1.name = "Bob Updated"
+    })
+
+    expect(result.current).toBe(user2)
+
+    act(() => {
+      result.current.name = "Alice Updated"
+    })
+
+    expect(result.current).not.toBe(user2)
+    expect(result.current).toEqual({ name: "Alice Updated" })
+  })
+
   it("when running forgiven mutation mode, subsequent mutations can be triggered off the same node reference", () => {
     const state = { count: 0 }
     const store = new Arbor(state, { mode: MutationMode.FORGIVEN })

--- a/packages/arbor-react/src/useArbor.test.ts
+++ b/packages/arbor-react/src/useArbor.test.ts
@@ -75,7 +75,7 @@ describe("useArbor", () => {
     }
 
     const { result, rerender } = renderHook(
-      ({ store, selector }) => useArbor(store, selector),
+      (props) => useArbor(props.store, props.selector),
       { initialProps }
     )
 

--- a/packages/arbor-react/src/useArbor.test.ts
+++ b/packages/arbor-react/src/useArbor.test.ts
@@ -53,6 +53,21 @@ describe("useArbor", () => {
     expect(result.current).toEqual({ name: "Alice Updated" })
   })
 
+  it("skips subscription if no node is selected", () => {
+    const store = new Arbor<{ name: string }[]>([
+      { name: "Bob" },
+      { name: "Alice" },
+    ])
+
+    const { result } = renderHook(() => useArbor(store, (users) => users[2]))
+
+    expect(result.current).toBe(undefined)
+
+    act(() => {
+      store.root[0].name = "Bob Updated"
+    })
+  })
+
   it("when running forgiven mutation mode, subsequent mutations can be triggered off the same node reference", () => {
     const state = { count: 0 }
     const store = new Arbor(state, { mode: MutationMode.FORGIVEN })

--- a/packages/arbor-react/src/useArbor.test.ts
+++ b/packages/arbor-react/src/useArbor.test.ts
@@ -54,19 +54,7 @@ describe("useArbor", () => {
     expect(result.current).toEqual({ name: "Alice Updated" })
   })
 
-  it("skips state update if no node is selected", () => {
-    const store = new Arbor<User[]>([{ name: "Bob" }, { name: "Alice" }])
-
-    const { result } = renderHook(() => useArbor(store, (users) => users[2]))
-
-    expect(result.current).toBe(undefined)
-
-    act(() => {
-      store.root[0].name = "Bob Updated"
-    })
-  })
-
-  it("reselects observed node across re-renderings", () => {
+  it("handles selector changes across re-renderings", () => {
     const store = new Arbor<User[]>([{ name: "Bob" }, { name: "Alice" }])
 
     const initialProps = {
@@ -87,6 +75,16 @@ describe("useArbor", () => {
     })
 
     expect(result.current).toBe(store.root[1])
+  })
+
+  it("supports derived data", () => {
+    const store = new Arbor<User[]>([{ name: "Bob" }, { name: "Alice" }])
+
+    const { result } = renderHook(() =>
+      useArbor(store, (users) => users.length)
+    )
+
+    expect(result.current).toBe(2)
   })
 
   it("when running forgiven mutation mode, subsequent mutations can be triggered off the same node reference", () => {

--- a/packages/arbor-react/src/useArbor.ts
+++ b/packages/arbor-react/src/useArbor.ts
@@ -1,4 +1,4 @@
-import Arbor, { INode } from "@arborjs/store"
+import type Arbor from "@arborjs/store"
 import { useEffect, useState } from "react"
 
 /**
@@ -31,27 +31,19 @@ import { useEffect, useState } from "react"
  * @param store an instance of the Arbor state tree.
  * @returns the current state of the Arbor state tree.
  */
-export default function useArbor<T extends object, S extends object = T>(
+export default function useArbor<T extends object, S = T>(
   store: Arbor<T>,
   selector = (root: T): S => root as unknown as S
 ) {
-  const value = selector(store.root)
-  const [state, setState] = useState(value)
+  const [state, setState] = useState(selector(store.root))
 
   useEffect(() => {
-    setState(value)
-  }, [value])
+    setState(selector(store.root))
+  }, [selector])
 
   useEffect(
-    () =>
-      store.subscribe((newState) => {
-        const node = value as INode<S>
-        const newNode = node?.$path.walk(newState)
-        if (newNode !== node) {
-          setState(newNode as S)
-        }
-      }),
-    [store, value]
+    () => store.subscribe(() => setState(selector(store.root))),
+    [selector, store]
   )
 
   return state

--- a/packages/arbor-react/src/useArbor.ts
+++ b/packages/arbor-react/src/useArbor.ts
@@ -42,18 +42,20 @@ export default function useArbor<T extends object, S extends object = T>(
 
   const node = state as INode<typeof state>
 
-  const unsubscribe = useMemo(
-    () =>
-      store.subscribe((newState) => {
-        const newNode = node.$path.walk(newState)
-        if (newNode !== node) {
-          setState(newNode as unknown as S)
-        }
-      }),
-    [store]
-  )
+  useEffect(() => {
+    // No state tree node was selected for subscription.
+    // TODO: Should this throw an error instead?
+    if (!node) return () => {}
 
-  useEffect(() => unsubscribe, [unsubscribe])
+    const unsubscribe = store.subscribe((newState) => {
+      const newNode = node.$path.walk(newState)
+      if (newNode !== node) {
+        setState(newNode as unknown as S)
+      }
+    })
+
+    return unsubscribe
+  }, [store])
 
   return state
 }

--- a/packages/arbor-react/src/useArbor.ts
+++ b/packages/arbor-react/src/useArbor.ts
@@ -1,6 +1,5 @@
-import type Arbor from "@arborjs/store"
-import { INode } from "@arborjs/store"
-import { useEffect, useMemo, useState } from "react"
+import Arbor, { INode } from "@arborjs/store"
+import { useEffect, useState } from "react"
 
 /**
  * This hook binds a React component to a given Arbor store.


### PR DESCRIPTION
This will allow React components to subscribe to changes to specific state tree nodes, a mechanism that can also be used to compute derived data.

Take the following store as an example:

```ts
interface User {
  id: number
  name: string
}

const store = useArbor<User[]>([
  { id: 1, name: "Alice", active: true },
  { id: 2, name: "Bob", active: false },
])
```

If we needed to create a component that is interested in changes to the user `Bob` but should not re-render when `Alice` is updated, we would go about it as follows:

```tsx
function UserProfile({ id }) {
  const user = useArbor(store, users => users.find(u => u.id === id))

  return (
    <div>{user.name}</div>
  )
}
```

We can rely on this same mechanism to compute derived data. For example:

```tsx
function UsersSummary() {
  const activeCount = useArbor(store, users => users.filter(u => u.active).length)
  const inactiveCount = useArbor(store, users => users.filter(u => !u.active).length)

  return <span>{activeCount} of {inactiveCount} users active</span>
}
```

The example above shows a React component that displays the active users count and only re-renders when either `activeCount` or `inactiveCount` changes.