### PR TITLE
Remove unused  API method

### DIFF
--- a/packages/arbor-store/src/NodeHandler.test.ts
+++ b/packages/arbor-store/src/NodeHandler.test.ts
@@ -401,31 +401,6 @@ describe("NodeHandler", () => {
     })
   })
 
-  describe("#$flush", () => {
-    it("resets the node's children cache", () => {
-      const state = {
-        users: [{ name: "User 1", address: { street: "Street 1" } }],
-      }
-
-      const tree = new Arbor(state)
-
-      const node = new Proxy(
-        state,
-        new NodeHandler<State>(tree, Path.root, state) as ProxyHandler<State>
-      ) as Node<State>
-
-      // Warms up the cache: this will cache the 'users' child node
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      node.users
-
-      expect(node.$children.has(state.users)).toBe(true)
-
-      node.$flush()
-
-      expect(node.$children.has(state.users)).toBe(false)
-    })
-  })
-
   describe("#$clone", () => {
     it("returns a shallow copy of the node", () => {
       const state = {

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -25,10 +25,6 @@ export default class NodeHandler<T extends object> implements ProxyHandler<T> {
     return this.$tree.createNode(this.$path, clone, this.$children)
   }
 
-  $flush(): void {
-    this.$children.reset()
-  }
-
   get(target: T, prop: string, proxy: Node<T>) {
     // Access $unwrap, $clone, $children, etc...
     const handlerApiAccess = Reflect.get(this, prop, proxy)

--- a/packages/arbor-store/src/types.ts
+++ b/packages/arbor-store/src/types.ts
@@ -77,7 +77,6 @@ export interface IStateTree<T extends object = object> {
 export interface INode<T extends object> {
   $unwrap(): T
   $clone(): Node<T>
-  $flush(): void
   get $path(): Path
   get $children(): ICacheable
 }


### PR DESCRIPTION
There's not yet a use-case for this so will keep the public API to a minimum for now.