### PR TITLE
Implement an Immer-like produce helper function

### DIFF
--- a/packages/arbor-react/src/index.ts
+++ b/packages/arbor-react/src/index.ts
@@ -2,6 +2,7 @@ import Arbor, {
   Path,
   Collection,
   ArborNode,
+  produce,
   stitch,
   MutationMode,
 } from "@arborjs/store"
@@ -12,6 +13,7 @@ export {
   Collection,
   useArbor,
   Path,
+  produce,
   MutationMode,
   stitch,
   ArborNode,

--- a/packages/arbor-store/src/index.ts
+++ b/packages/arbor-store/src/index.ts
@@ -1,5 +1,6 @@
 import Path from "./Path"
 import stitch from "./stitch"
+import produce from "./produce"
 import { Mutation } from "./mutate"
 import ArborNode from "./ArborNode"
 import Collection from "./Collection"
@@ -30,6 +31,7 @@ export {
   Collection,
   ArborNode,
   Path,
+  produce,
   MutationMode,
   stitch,
   Arbor as default,

--- a/packages/arbor-store/src/produce.test.ts
+++ b/packages/arbor-store/src/produce.test.ts
@@ -1,0 +1,88 @@
+import Arbor from "./Arbor"
+import isNode from "./isNode"
+import produce from "./produce"
+import ArborNode from "./ArborNode"
+
+class Todo extends ArborNode<Todo> {
+  id: number
+  text: string
+  completed = false
+}
+
+const currentState = [
+  new Todo({ id: 123, text: "Do the dishes" }),
+  new Todo({ id: 124, text: "Walk the dogs" }),
+]
+
+describe("mutate", () => {
+  it("produces the next state off the current state", () => {
+    const nextState = produce((state) => {
+      state[0].completed = true
+      state[0].text = "Clean the house"
+    })(currentState)
+
+    expect(nextState).not.toBe(currentState)
+    expect(nextState[0]).toBeInstanceOf(Todo)
+    expect(nextState[0]).not.toBe(currentState[0])
+    expect(nextState[1]).toBeInstanceOf(Todo)
+    expect(nextState[1]).toBe(currentState[1])
+    expect(nextState).toEqual([
+      { id: 123, completed: true, text: "Clean the house" },
+      { id: 124, completed: false, text: "Walk the dogs" },
+    ])
+  })
+
+  it("performs a noop when given state is null", () => {
+    const nextState = produce((state) => {
+      state[0].completed = true
+      state[0].text = "Clean the house"
+    })(null)
+
+    expect(nextState).toBe(null)
+  })
+
+  it("performs a noop when given state is undefined", () => {
+    const nextState = produce((state) => {
+      state[0].completed = true
+      state[0].text = "Clean the house"
+    })(undefined)
+
+    expect(nextState).toBe(undefined)
+  })
+
+  it("throws an error when state is not an object", () => {
+    expect(() => {
+      produce((state) => {
+        state[0].completed = true
+        state[0].text = "Clean the house"
+      })(5 as any)
+    }).toThrowError()
+
+    expect(() => {
+      produce((state) => {
+        state[0].completed = true
+        state[0].text = "Clean the house"
+      })("Some string" as any)
+    }).toThrowError()
+
+    expect(() => {
+      produce((state) => {
+        state[0].completed = true
+        state[0].text = "Clean the house"
+      })(new Date())
+    }).toThrowError()
+  })
+
+  it("automatically unwraps Arbor nodes when used as current state", () => {
+    const store = new Arbor(currentState)
+
+    const nextState = produce((state) => {
+      state[0].completed = true
+      state[0].text = "Clean the house"
+    })(store.root)
+
+    expect(isNode(nextState)).toBe(false)
+    expect(isNode(nextState[0])).toBe(false)
+    expect(isNode(nextState[1])).toBe(false)
+  })
+})

--- a/packages/arbor-store/src/produce.ts
+++ b/packages/arbor-store/src/produce.ts
@@ -1,0 +1,14 @@
+import Arbor from "./Arbor"
+import { Mutation } from "./mutate"
+
+export default function produce<T extends object>(mutation: Mutation<T>) {
+  return (state: T) => {
+    if (state == null) {
+      return state
+    }
+
+    const store = new Arbor(state)
+    mutation(store.root)
+    return store.root.$unwrap()
+  }
+}


### PR DESCRIPTION
Provides a `produce` helper function, similar to [Immer](https://github.com/immerjs/immer), which allows users with more specific needs to still leverage Arbor's simplicity without having to commit to using Arbor as their unique data store.

In a React, one can leverage this helper in order to make state updates less cumbersome, example:

```tsx
import { v4 as uuid } from "uuid"
import { produce } from "@arborjs/store"

interface Todo {
  id: string
  text: string
  completed: boolean
}

export default function App() {
  const [todos, setTodos] = useState<Todo[]>([])
  const [inputValue, setInputValue] = useState("")

  return (
    <div className="App">
      <form
        onSubmit={(e) => {
          e.preventDefault()
          setTodos(
            produce((state) => state.push({ id: uuid(), text: inputValue, completed: false }))
          )
          setInputValue("")
        }}
      >
        <input
          type="text"
          value={inputValue}
          onChange={(e) => (setInputValue(e.target.value))}
        />
        <button>Add</button>
      </form>
      <ul>
        {todos.map((todo) => (
          <li key={todo.id}>{todo.text}</li>
        ))}
      </ul>
    </div>
  )
}
```