### PR TITLE
Implement useArborState hook

### DIFF
--- a/packages/arbor-react/src/useArborState.test.ts
+++ b/packages/arbor-react/src/useArborState.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react-hooks/native"
+
+import useArborState from "./useArborState"
+
+describe("useArborState", () => {
+  it("initializes the state with initial data", () => {
+    const initialState = {
+      users: [
+        { name: "Alice", address: { street: "Walnut 123" } },
+        { name: "Bob", address: { street: "Walnut 124" } },
+      ],
+    }
+
+    const { result } = renderHook(() => useArborState(initialState))
+    const [state] = result.current
+
+    expect(state).toBe(initialState)
+  })
+
+  it("updates the state applying structural sharing", () => {
+    const initialState = {
+      users: [
+        { name: "Alice", address: { street: "Walnut 123" }, notifications: {} },
+        { name: "Bob", address: { street: "Walnut 124" }, notifications: {} },
+      ],
+    }
+
+    const { result } = renderHook(() => useArborState(initialState))
+    const [state, setState] = result.current
+
+    act(() => {
+      setState((currentState) => {
+        currentState.users[0].address.street = "Walnut 1234"
+      })
+    })
+
+    const [newState, newSetState] = result.current
+
+    expect(newSetState).toBe(setState)
+    expect(newState).not.toBe(state)
+    expect(newState.users).not.toBe(state.users)
+    expect(newState.users[0]).not.toBe(state.users[0])
+    expect(newState.users[0].address).not.toBe(state.users[0].address)
+    expect(newState.users[0].notifications).toBe(state.users[0].notifications)
+    expect(newState.users[1]).toBe(state.users[1])
+    expect(newState).toEqual({
+      users: [
+        {
+          name: "Alice",
+          address: { street: "Walnut 1234" },
+          notifications: {},
+        },
+        { name: "Bob", address: { street: "Walnut 124" }, notifications: {} },
+      ],
+    })
+  })
+})

--- a/packages/arbor-react/src/useArborState.ts
+++ b/packages/arbor-react/src/useArborState.ts
@@ -1,0 +1,15 @@
+import { useCallback, useState } from "react"
+import { Mutation, produce } from "@arborjs/store"
+
+export type ArborState<T extends object> = [T, (m: Mutation<T>) => void]
+
+export default function useArborState<T extends object>(
+  initial: T
+): ArborState<T> {
+  const [value, setValue] = useState(initial)
+  const setState = useCallback((mutation: Mutation<T>) => {
+    setValue(produce(mutation))
+  }, [])
+
+  return [value, setState]
+}


### PR DESCRIPTION
Arbor proxy mechanism adds a little overhead that in most cases is negligible. However, in cases where read speed in very large data structures is crucial, one can resort to this hook which allows one to perform read operations on the plain state object.

Example:

```tsx
function MyApp() {
  const [state, setState] = useArborState({
    users: [
      { name: "Alice", address: { street: "Walnut 123" }, notifications: {} },
      { name: "Bob", address: { street: "Walnut 124" }, notifications: {} },
    ],
  })

  const handleAddUser = (user) => {
    setState(state => state.users.push(user))
  }

  return (
    <ul>
      {state.users.map((user, index) => (
        <li key={index}>{user.name}</li>
      ))}
    </ul>
  )
}
```