### PR TITLE
Improve build process and perf reports

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+default

--- a/packages/arbor-plugins/package.json
+++ b/packages/arbor-plugins/package.json
@@ -54,7 +54,8 @@
     "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest --passWithNoTests",
     "dev": "jest --watch",
-    "build": "yarn clean && node ../../tools/build.js && yarn tsc",
+    "build": "yarn clean && NODE_ENV=production node ../../tools/build.js && yarn tsc",
+    "build:dev": "yarn clean && NODE_ENV=development node ../../tools/build.js && yarn tsc",
     "prepublish": "yarn build",
     "publish": "np"
   }

--- a/packages/arbor-react/package.json
+++ b/packages/arbor-react/package.json
@@ -55,7 +55,8 @@
     "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest --passWithNoTests",
     "dev": "jest --watch",
-    "build": "yarn clean && node ../../tools/build.js && yarn tsc",
+    "build": "yarn clean && NODE_ENV=production node ../../tools/build.js && yarn tsc",
+    "build:dev": "yarn clean && NODE_ENV=development node ../../tools/build.js && yarn tsc",
     "prepublish": "yarn build",
     "publish": "np"
   },

--- a/packages/arbor-store/package.json
+++ b/packages/arbor-store/package.json
@@ -51,7 +51,8 @@
     "test": "jest --passWithNoTests",
     "test:perf": "node --stack-size=200000 --expose-gc perf/index.mjs",
     "dev": "jest --watch",
-    "build": "yarn clean && node ../../tools/build.js && yarn tsc",
+    "build": "yarn clean && NODE_ENV=production node ../../tools/build.js && yarn tsc",
+    "build:dev": "yarn clean && NODE_ENV=development node ../../tools/build.js && yarn tsc",
     "prepublish": "yarn build",
     "publish": "np"
   }

--- a/packages/arbor-store/perf/memory.perf.mjs
+++ b/packages/arbor-store/perf/memory.perf.mjs
@@ -1,10 +1,14 @@
 import { memoryUsage } from "process"
 
 import Arbor from "../dist/index.mjs"
-import { createDeeplyNestedState, readRecursevly } from "./helpers.mjs"
+import {
+  createDeeplyNestedState,
+  defaultDepth,
+  readRecursevly,
+} from "./helpers.mjs"
 
 export function checkMemoryAllocationWhenProduceNextStateViaArbor() {
-  console.log("\nHeap Allocation")
+  console.log(`\nHeap Allocation (State Tree Depth: ${defaultDepth})`)
   global.gc()
   const initial = memoryUsage()
   const state = createDeeplyNestedState()
@@ -38,6 +42,17 @@ export function checkMemoryAllocationWhenProduceNextStateViaArbor() {
   console.log(
     "  After mutating leaf node",
     (afterMutatingLeafNode.heapUsed - afterAccessingLeafNode.heapUsed) / 1000,
+    "Kb"
+  )
+
+  const newLeafNode = readRecursevly(store.root)
+  newLeafNode.newProp = "mutating leaf node..."
+  const afterMutatingLeafNodeASecondTime = memoryUsage()
+  console.log(
+    "  After mutating leaf node a second time",
+    (afterMutatingLeafNodeASecondTime.heapUsed -
+      afterMutatingLeafNode.heapUsed) /
+      1000,
     "Kb"
   )
 }

--- a/packages/arbor-store/perf/mutations.perf.mjs
+++ b/packages/arbor-store/perf/mutations.perf.mjs
@@ -20,7 +20,7 @@ export function produceNextStateViaArbor() {
   node.newProp = "mutating leaf node..."
   performance.mark("finish")
   performance.measure(
-    `Producing next state tree via Arbor mutation (depth = ${defaultDepth})`,
+    `Producing the next state tree via Arbor mutation (depth = ${defaultDepth})`,
     "start",
     "finish"
   )
@@ -37,7 +37,7 @@ export function produceNextStateViaArborProducer() {
   })
   performance.mark("finish")
   performance.measure(
-    `Producing next state tree via Arbor producer (depth = ${defaultDepth})`,
+    `Producing the next state tree via Arbor producer (depth = ${defaultDepth})`,
     "start",
     "finish"
   )
@@ -54,7 +54,7 @@ export function produceNextStateViaImmerProducer() {
   })
   performance.mark("finish")
   performance.measure(
-    `Producing next state tree via Immer producer (depth = ${defaultDepth})`,
+    `Producing the next state tree via Immer producer (depth = ${defaultDepth})`,
     "start",
     "finish"
   )
@@ -68,7 +68,7 @@ export function produceNextStateViaManualReducer() {
   reduceRecursevly(state)
   performance.mark("finish")
   performance.measure(
-    `Producing next state tree via plain reducer (depth = ${defaultDepth})`,
+    `Producing the next state tree via plain reducer (depth = ${defaultDepth})`,
     "start",
     "finish"
   )

--- a/packages/arbor-store/perf/traversing.perf.mjs
+++ b/packages/arbor-store/perf/traversing.perf.mjs
@@ -1,7 +1,11 @@
 import { performance } from "perf_hooks"
 
 import Arbor from "../dist/index.mjs"
-import { createDeeplyNestedState, readRecursevly } from "./helpers.mjs"
+import {
+  createDeeplyNestedState,
+  defaultDepth,
+  readRecursevly,
+} from "./helpers.mjs"
 
 export function readingLeafNodeFromArborStateTree() {
   const state = createDeeplyNestedState()
@@ -11,7 +15,7 @@ export function readingLeafNodeFromArborStateTree() {
   readRecursevly(store.root)
   performance.mark("finish")
   performance.measure(
-    "Reading a leaf node within a very tall Arbor state tree",
+    `Reading a leaf node from an Arbor state tree (depth = ${defaultDepth})`,
     "start",
     "finish"
   )
@@ -20,7 +24,7 @@ export function readingLeafNodeFromArborStateTree() {
   readRecursevly(store.root)
   performance.mark("finish")
   performance.measure(
-    "Reading a leaf node within a very tall but cached Arbor state tree",
+    `Reading a leaf node from a cached Arbor state tree (depth = ${defaultDepth})`,
     "start",
     "finish"
   )
@@ -33,7 +37,7 @@ export function readingLeafNodeFromPlainObjectStateTree() {
   readRecursevly(state)
   performance.mark("finish")
   performance.measure(
-    "Reading a leaf node within a very tall plain object state tree",
+    `Reading a leaf node from a plain object state tree (depth = ${defaultDepth})`,
     "start",
     "finish"
   )

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -165,7 +165,8 @@ export default class Arbor<T extends object = {}> {
       this.#root = newRoot
 
       this.notify(newRoot, oldRootValue)
-    } else {
+    } else if (global.DEBUG) {
+      // eslint-disable-next-line no-console
       console.warn(
         `Could not mutate path ${path}. The path no longer exists within the state tree.`
       )

--- a/packages/arbor-store/src/mutate.ts
+++ b/packages/arbor-store/src/mutate.ts
@@ -43,7 +43,6 @@ export default function mutate<T extends object, K extends object>(
 
     return root
   } catch (e) {
-    console.debug(e)
     return undefined
   }
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -14,6 +14,9 @@ const config = {
   bundle: true,
   minify: true,
   external: Object.keys(dependencies).concat(Object.keys(peerDependencies)),
+  define: {
+    "global.DEBUG": false,
+  },
 }
 
 build({

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,8 +1,10 @@
+const process = require("process")
 const { build } = require("esbuild")
 
 const cwd = process.cwd()
 const dist = `${cwd}/dist`
 const src = `${cwd}/src`
+const isProduction = process.env.NODE_ENV === "production"
 
 const {
   dependencies = {},
@@ -12,10 +14,10 @@ const {
 const config = {
   entryPoints: [`${src}/index.ts`],
   bundle: true,
-  minify: true,
+  minify: isProduction,
   external: Object.keys(dependencies).concat(Object.keys(peerDependencies)),
   define: {
-    "global.DEBUG": false,
+    "global.DEBUG": !isProduction,
   },
 }
 


### PR DESCRIPTION
1. Prune console.logs from final build (when `DEBUG !== true`);
2. Improve perf reports a little further.