### PR TITLE
Better error handling

### DIFF
--- a/packages/arbor-store/src/ArborNode.test.ts
+++ b/packages/arbor-store/src/ArborNode.test.ts
@@ -1,6 +1,7 @@
 import Arbor from "./Arbor"
 import ArborNode from "./ArborNode"
 import Collection from "./Collection"
+import { NotAnArborNodeError } from "./errors"
 
 describe("ArborNode", () => {
   class Todo extends ArborNode<Todo> {
@@ -25,6 +26,12 @@ describe("ArborNode", () => {
       expect(store.root.fetch("abc")).toBeUndefined()
       expect(todo1.isAttached()).toBe(false)
     })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.detach()).toThrowError(NotAnArborNodeError)
+    })
   })
 
   describe("#attach", () => {
@@ -47,6 +54,12 @@ describe("ArborNode", () => {
 
       expect(todo1.isAttached()).toBe(true)
       expect(store.root.fetch("abc")).toBe(todo1)
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.attach()).toThrowError(NotAnArborNodeError)
     })
   })
 
@@ -72,6 +85,12 @@ describe("ArborNode", () => {
         new Todo({ uuid: "abc", text: "Walk the dogs", completed: false })
       )
     })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.merge({})).toThrowError(NotAnArborNodeError)
+    })
   })
 
   describe("#reload", () => {
@@ -96,6 +115,12 @@ describe("ArborNode", () => {
       expect(todo).not.toBe(store.root.fetch("abc"))
       expect(reloaded).toBe(store.root.fetch("abc"))
     })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.reload()).toThrowError(NotAnArborNodeError)
+    })
   })
 
   describe("#isAttached", () => {
@@ -112,6 +137,12 @@ describe("ArborNode", () => {
       expect(todo.isAttached()).toBe(true)
       store.root.delete("abc")
       expect(todo.isAttached()).toBe(false)
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.isAttached()).toThrowError(NotAnArborNodeError)
     })
   })
 
@@ -130,6 +161,12 @@ describe("ArborNode", () => {
       todo.text = "Walk the dogs"
       expect(todo.isStale()).toBe(true)
     })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.isStale()).toThrowError(NotAnArborNodeError)
+    })
   })
 
   describe("#path", () => {
@@ -144,6 +181,12 @@ describe("ArborNode", () => {
       const todo = store.root.todos.fetch("abc")
 
       expect(todo.path).toBe("/todos/abc")
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const todo = new Todo()
+
+      expect(() => todo.path).toThrowError(NotAnArborNodeError)
     })
   })
 })

--- a/packages/arbor-store/src/ArborNode.ts
+++ b/packages/arbor-store/src/ArborNode.ts
@@ -1,4 +1,5 @@
 import isNode from "./isNode"
+import { NotAnArborNodeError } from "./errors"
 
 import type { AttributesOf, Node } from "./Arbor"
 
@@ -8,8 +9,8 @@ export default class ArborNode<T extends object> {
   }
 
   detach() {
-    const node = this as unknown as Node<T>
-    if (!isNode(node)) return
+    const node = this
+    if (!isNode(node)) throw new NotAnArborNodeError()
 
     const parentPath = node.$path.parent
     const id = node.$path.props[node.$path.props.length - 1]
@@ -19,8 +20,8 @@ export default class ArborNode<T extends object> {
   }
 
   attach(): ArborNode<T> {
-    const node = this as unknown as Node<T>
-    if (!isNode(node)) return this
+    const node = this
+    if (!isNode(node)) throw new NotAnArborNodeError()
 
     const parentPath = node.$path.parent
     const id = node.$path.props[node.$path.props.length - 1]
@@ -32,19 +33,19 @@ export default class ArborNode<T extends object> {
   }
 
   merge(attributes: Partial<AttributesOf<T>>): ArborNode<T> {
-    const node = this as unknown as Node<T>
-    if (!isNode(node)) return this
+    if (!isNode(this)) throw new NotAnArborNodeError()
 
-    node.$tree.mutate(node.$path, (value) => {
+    this.$tree.mutate(this.$path, (value) => {
       Object.assign(value, attributes)
     })
 
-    return node.$tree.getNodeAt(node.$path)
+    return this.$tree.getNodeAt(this.$path)
   }
 
   reload(): ArborNode<T> {
-    const node = this as unknown as Node<T>
-    return isNode(node) ? node.$tree.getNodeAt(node.$path) : this
+    if (!isNode(this)) throw new NotAnArborNodeError()
+
+    return this.$tree.getNodeAt(this.$path)
   }
 
   isAttached(): boolean {
@@ -56,7 +57,8 @@ export default class ArborNode<T extends object> {
   }
 
   get path(): string {
-    const node = this as unknown as Node<T>
-    return node.$path.toString()
+    if (!isNode(this)) throw new NotAnArborNodeError()
+
+    return this.$path.toString()
   }
 }

--- a/packages/arbor-store/src/ArborNode.ts
+++ b/packages/arbor-store/src/ArborNode.ts
@@ -1,7 +1,7 @@
 import isNode from "./isNode"
 import { NotAnArborNodeError } from "./errors"
 
-import type { AttributesOf, Node } from "./Arbor"
+import type { AttributesOf } from "./Arbor"
 
 export default class ArborNode<T extends object> {
   constructor(attributes: Partial<AttributesOf<T>> = {}) {

--- a/packages/arbor-store/src/Collection.test.ts
+++ b/packages/arbor-store/src/Collection.test.ts
@@ -1,5 +1,6 @@
 import Arbor from "./Arbor"
 import Collection from "./Collection"
+import { MissingUUIDError, NotAnArborNodeError } from "./errors"
 
 import type { Node } from "./Arbor"
 
@@ -47,7 +48,15 @@ describe("Collection", () => {
 
       expect(() =>
         store.root.add({ uuid: undefined, name: "Bob" })
-      ).toThrowError("Collection items must have a string 'uuid'")
+      ).toThrowError(MissingUUIDError)
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() =>
+        collection.add({ uuid: undefined, name: "Bob" })
+      ).toThrowError(NotAnArborNodeError)
     })
   })
 
@@ -75,10 +84,18 @@ describe("Collection", () => {
       const store = new Arbor(new Collection<User>())
 
       expect(() => store.root.addMany(user1, user2)).toThrowError(
-        "Collection items must have a string 'uuid'"
+        MissingUUIDError
       )
 
       expect(store.root.length).toBe(0)
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() =>
+        collection.addMany({ uuid: undefined, name: "Bob" })
+      ).toThrowError(NotAnArborNodeError)
     })
   })
 
@@ -133,6 +150,14 @@ describe("Collection", () => {
       const updatedItem = store.root.merge(user, { name: "Bob Updated" })
 
       expect(updatedItem).toBeUndefined()
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() =>
+        collection.merge({ uuid: undefined, name: "Bob" }, {})
+      ).toThrowError(NotAnArborNodeError)
     })
   })
 
@@ -196,6 +221,17 @@ describe("Collection", () => {
       expect(store.root.fetch("abc")).toBe(originalBob)
       expect(store.root.fetch("abd")).toBe(originalAlice)
       expect(store.root.fetch("abe")).toBe(originalBarbara)
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() =>
+        collection.mergeBy(
+          () => true,
+          () => ({})
+        )
+      ).toThrowError(NotAnArborNodeError)
     })
   })
 
@@ -291,6 +327,15 @@ describe("Collection", () => {
       const user = store.root.fetch("abc") as Node<User>
 
       expect(user).toBeUndefined()
+    })
+
+    it("fetches the item even when the collection is not bound to an Arbor store", () => {
+      const user1 = { uuid: "abc", name: "Bob" }
+      const user2 = { uuid: "abd", name: "Alice" }
+      const collection = new Collection<User>(user1, user2)
+
+      expect(collection.fetch("abc")).toBe(user1)
+      expect(collection.fetch("abd")).toBe(user2)
     })
   })
 
@@ -533,6 +578,14 @@ describe("Collection", () => {
       expect(deleted).toBe(user)
       expect(store.root.fetch("abc")).toBeUndefined()
     })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() => collection.delete("some uuid")).toThrowError(
+        NotAnArborNodeError
+      )
+    })
   })
 
   describe("#deleteBy", () => {
@@ -550,6 +603,14 @@ describe("Collection", () => {
       expect(store.root.fetch("abc")).toBeUndefined()
       expect(store.root.fetch("abe")).toBeUndefined()
     })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() => collection.deleteBy(() => true)).toThrowError(
+        NotAnArborNodeError
+      )
+    })
   })
 
   describe("#clear", () => {
@@ -562,6 +623,12 @@ describe("Collection", () => {
       store.root.clear()
 
       expect(store.root.length).toBe(0)
+    })
+
+    it("throws an error when used on an instance not bound to an Arbor store", () => {
+      const collection = new Collection<User>()
+
+      expect(() => collection.clear()).toThrowError(NotAnArborNodeError)
     })
   })
 

--- a/packages/arbor-store/src/Collection.ts
+++ b/packages/arbor-store/src/Collection.ts
@@ -1,8 +1,6 @@
 import isNode from "./isNode"
 import { MissingUUIDError, NotAnArborNodeError } from "./errors"
 
-import type { Node } from "./Arbor"
-
 export type Predicate<T> = (item: T) => boolean
 export interface Item {
   uuid: string

--- a/packages/arbor-store/src/Collection.ts
+++ b/packages/arbor-store/src/Collection.ts
@@ -1,3 +1,6 @@
+import isNode from "./isNode"
+import { MissingUUIDError, NotAnArborNodeError } from "./errors"
+
 import type { Node } from "./Arbor"
 
 export type Predicate<T> = (item: T) => boolean
@@ -18,11 +21,12 @@ export default class Collection<T extends Item> {
   }
 
   addMany(...items: T[]): T[] {
-    const node = this as unknown as Node<T>
+    const node = this
+    if (!isNode(node)) throw new NotAnArborNodeError()
 
     items.forEach((item) => {
       if (item.uuid == null) {
-        throw new Error("Collection items must have a string 'uuid'")
+        throw new MissingUUIDError()
       }
     })
 
@@ -78,8 +82,10 @@ export default class Collection<T extends Item> {
   }
 
   merge(uuidOrItem: T | string, data: Partial<T>): T {
+    const node = this
+    if (!isNode(node)) throw new NotAnArborNodeError()
+
     const item = this.fetch(uuidOrItem)
-    const node = this as unknown as Node<T>
 
     if (item === undefined) {
       return undefined
@@ -98,8 +104,9 @@ export default class Collection<T extends Item> {
   }
 
   mergeBy(predicate: Predicate<T>, updateFn: (item: T) => Partial<T>): T[] {
+    const node = this
     const updatedIds: string[] = []
-    const node = this as unknown as Node<T>
+    if (!isNode(node)) throw new NotAnArborNodeError()
 
     node.$tree.mutate<Collection<T>>(node.$path, (collection) => {
       Object.values(collection).forEach((value: T) => {
@@ -122,7 +129,9 @@ export default class Collection<T extends Item> {
 
   fetch(uuidOrItem: string | T): T | undefined {
     const uuid = extractUUIDFrom(uuidOrItem)
-    const node = this as unknown as Node<T>
+    const node = this
+
+    if (!isNode(node)) return this[uuid]
 
     return uuid ? node.$tree.getNodeAt(node.$path.child(uuid)) : undefined
   }
@@ -211,8 +220,10 @@ export default class Collection<T extends Item> {
   }
 
   delete(uuidOrItem: string | T) {
+    const node = this
+    if (!isNode(node)) throw new NotAnArborNodeError()
+
     let deleted: T
-    const node = this as unknown as Node<T>
     const uuid = extractUUIDFrom(uuidOrItem)
 
     if (uuid) {
@@ -226,8 +237,9 @@ export default class Collection<T extends Item> {
   }
 
   deleteBy(predicate: Predicate<T>): T[] {
+    const node = this
     const deleted: T[] = []
-    const node = this as unknown as Node<T>
+    if (!isNode(node)) throw new NotAnArborNodeError()
 
     node.$tree.mutate<Collection<T>>(node.$path, (collection) => {
       Object.values(collection).forEach((value: T) => {
@@ -242,7 +254,9 @@ export default class Collection<T extends Item> {
   }
 
   clear() {
-    const node = this as unknown as Node<T>
+    const node = this
+    if (!isNode(node)) throw new NotAnArborNodeError()
+
     node.$tree.mutate(node.$path, (collection) => {
       Object.keys(collection).forEach((key) => {
         delete collection[key]

--- a/packages/arbor-store/src/errors.ts
+++ b/packages/arbor-store/src/errors.ts
@@ -1,0 +1,13 @@
+/* eslint-disable max-classes-per-file */
+
+export class ArborError extends Error {}
+export class MissingUUIDError extends ArborError {
+  constructor() {
+    super("Collection items must have a string 'uuid'")
+  }
+}
+export class NotAnArborNodeError extends ArborError {
+  constructor() {
+    super("Object not bound to an Arbor store")
+  }
+}


### PR DESCRIPTION
In order to avoid confusion, some operations (mostly mutations) triggered on an instance of a `Collection` or `ArborNode` that are not bound to an Arbor store will throw an error.