### PR TITLE
Allow mutating a node via Arbor#mutate in addition to a path

### DIFF
--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import Path from "./Path"
-import Arbor from "./Arbor"
+import Arbor, { Node } from "./Arbor"
 import ArborNode from "./ArborNode"
 import Collection from "./Collection"
 import { warmup } from "./test.helpers"
@@ -64,6 +64,56 @@ describe("Arbor", () => {
 
       expect(Path.root.walk(store.root)).toBe(store.root)
       expect(Path.parse("/users/1").walk(store.root)).toBe(store.root.users[1])
+    })
+  })
+
+  describe("#mutate", () => {
+    it("mutates a given path within the state tree", () => {
+      const initialState = {
+        users: [{ name: "Bob" }, { name: "Alice" }],
+      }
+
+      const store = new Arbor(initialState)
+      const initialRoot = store.root
+      const initialUsers = store.root.users
+      const initialUser0 = store.root.users[0]
+      const initialUser1 = store.root.users[1]
+
+      store.mutate<{ name: string }>(Path.parse("/users/0"), (user) => {
+        user.name = "Bob 2"
+      })
+
+      expect(store.root).not.toBe(initialRoot)
+      expect(store.root.users).not.toBe(initialUsers)
+      expect(store.root.users[0]).not.toBe(initialUser0)
+      expect(store.root.users[1]).toBe(initialUser1)
+      expect(store.root).toEqual({
+        users: [{ name: "Bob 2" }, { name: "Alice" }],
+      })
+    })
+
+    it("mutates a given node within the state tree", () => {
+      const initialState = {
+        users: [{ name: "Bob" }, { name: "Alice" }],
+      }
+
+      const store = new Arbor(initialState)
+      const initialRoot = store.root
+      const initialUsers = store.root.users
+      const initialUser0 = store.root.users[0] as Node<{ name: string }>
+      const initialUser1 = store.root.users[1]
+
+      store.mutate(initialUser0, (user) => {
+        user.name = "Bob 2"
+      })
+
+      expect(store.root).not.toBe(initialRoot)
+      expect(store.root.users).not.toBe(initialUsers)
+      expect(store.root.users[0]).not.toBe(initialUser0)
+      expect(store.root.users[1]).toBe(initialUser1)
+      expect(store.root).toEqual({
+        users: [{ name: "Bob 2" }, { name: "Alice" }],
+      })
     })
   })
 

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -1,7 +1,8 @@
 import Path from "./Path"
-import mutate, { Mutation } from "./mutate"
+import isNode from "./isNode"
 import NodeCache from "./NodeCache"
 import NodeHandler from "./NodeHandler"
+import mutate, { Mutation } from "./mutate"
 import NodeArrayHandler from "./NodeArrayHandler"
 
 /**
@@ -153,7 +154,8 @@ export default class Arbor<T extends object = {}> {
    * @param path the path within the state tree affected by the mutation.
    * @param mutation a function responsible for mutating the target node at the given path.
    */
-  mutate<V extends object>(path: Path, mutation: Mutation<V>) {
+  mutate<V extends object>(pathOrNode: Path | Node<V>, mutation: Mutation<V>) {
+    const path = isNode(pathOrNode) ? pathOrNode.$path : pathOrNode
     const oldRootValue = this.root.$unwrap()
     const newRoot = mutate(this.root, path, mutation)
 


### PR DESCRIPTION
Example:

```ts
class User extends ArborNode<User> {
  name: string
}

const store = new Arbor<User[]>([
  { name: "Bob" },
  { name: "Alice" },
])

const bob = store.root[0]

store.mutate(bob, user => {
  user.name = "Bob Wilson"
})
```

This will give developers a way to implement their own custom mutation logic and avoid multiple mutations being dispatched to the store when needing to change multiple fields within an object.

Note that the `user` argument passed into the mutate callback is a shallow copy of the original value wrapped by the Arbor node `bob`, e.g. so changing attributes like in the example above is Ok, however, mutating objects nested within `bob` requires you to handle the cloning of these nested objects (similar to how you'd do in Redux). In order to facilitate this procedure, one can rely on the [`clone`utility function](https://github.com/drborges/arbor/blob/main/packages/arbor-store/src/clone.test.ts#L21).