### PR TITLE
Recursively type Arbor state tree nodes.

### DIFF
--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
-import Path from "./Path"
-import Arbor, { MutationMode, Node } from "./Arbor"
+import Arbor, { MutationMode } from "./Arbor"
 import ArborNode from "./ArborNode"
 import Collection from "./Collection"
+import Path from "./Path"
 import { warmup } from "./test.helpers"
 
 describe("Arbor", () => {
@@ -190,7 +190,7 @@ describe("Arbor", () => {
       const store = new Arbor(initialState)
       const initialRoot = store.root
       const initialUsers = store.root.users
-      const initialUser0 = store.root.users[0] as Node<{ name: string }>
+      const initialUser0 = store.root.users[0]
       const initialUser1 = store.root.users[1]
 
       store.mutate(initialUser0, (user) => {

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -187,9 +187,7 @@ export default class Arbor<T extends object = {}> {
    */
   mutate<V extends object>(pathOrNode: Path | Node<V>, mutation: Mutation<V>) {
     const path = isNode(pathOrNode) ? pathOrNode.$path : pathOrNode
-    const node = isNode(pathOrNode)
-      ? pathOrNode
-      : (path.walk(this.root) as Node<V>)
+    const node = isNode(pathOrNode) ? pathOrNode : (path.walk(this.root) as Node<V>)
     const oldRootValue = this.root.$unwrap()
     const newRoot = mutate(this.root, path, mutation)
 

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -15,7 +15,7 @@ export type ArrayNode<T> = Array<T extends object ? Node<T> : T> & {
       : Node<T>
     : T
 
-  $unwrap(): T
+  $unwrap(): T[]
   $clone(): ArrayNode<T>
   get $tree(): Arbor
   get $path(): Path

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -6,12 +6,42 @@ import mutate, { Mutation } from "./mutate"
 import NodeArrayHandler from "./NodeArrayHandler"
 
 /**
- * Represents an Arbor tree node.
+ * Describes an Arbor state tree Array node's API.
  */
-export type Node<T extends object = object> = T & {
+export type ArrayNode<T> = Array<T extends object ? Node<T> : T> & {
+  [key: number]: T extends object
+    ? T extends Array<infer D>
+      ? ArrayNode<D>
+      : Node<T>
+    : T
+
+  $unwrap(): T
+  $clone(): ArrayNode<T>
+  get $tree(): Arbor
+  get $path(): Path
+  get $children(): NodeCache
+}
+
+/**
+ * Recursively describes the props of an Arbor state tree node.
+ */
+export type NodeProps<T extends object> = {
+  [P in keyof T]: T[P] extends object
+    ? T[P] extends Function
+      ? T[P]
+      : T[P] extends Array<infer D>
+        ? ArrayNode<D>
+        : Node<T[P]>
+    : T[P]
+}
+
+/**
+ * Describes an Arbor state tree node's API.
+ */
+export type Node<T extends object = object> = NodeProps<T> & T & {
   $unwrap(): T
   $clone(): Node<T>
-  get $tree(): Arbor<T>
+  get $tree(): Arbor
   get $path(): Path
   get $children(): NodeCache
 }

--- a/packages/arbor-store/src/NodeArrayHandler.test.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.test.ts
@@ -18,8 +18,8 @@ describe("NodeArrayHandler", () => {
     const tree = new Arbor<User[]>(state)
     const node = new Proxy(
       state,
-      new NodeArrayHandler<User>(tree, Path.root, state) as ProxyHandler<User[]>
-    ) as Node<User[]>
+      new NodeArrayHandler(tree, Path.root, state) as ProxyHandler<User[]>
+    )
 
     expect(node).toBeInstanceOf(Array)
   })
@@ -30,9 +30,7 @@ describe("NodeArrayHandler", () => {
       const tree = new Arbor<User[]>(state)
       const node = new Proxy(
         state,
-        new NodeArrayHandler<User>(tree, Path.root, state) as ProxyHandler<
-          User[]
-        >
+        new NodeArrayHandler(tree, Path.root, state) as ProxyHandler<User[]>
       ) as Node<User[]>
 
       warmup(node[0].address)
@@ -85,8 +83,8 @@ describe("NodeArrayHandler", () => {
       const originalRoot = tree.root
       const originalBob = tree.root[0]
       const originalAlice = tree.root[1]
-      const first = tree.root.first as Node<User>
-      const last = tree.root.last as Node<User>
+      const first = tree.root.first
+      const last = tree.root.last
 
       expect(originalRoot).toBeInstanceOf(Users)
       expect(first.$unwrap()).toBe(state[0])

--- a/packages/arbor-store/src/NodeArrayHandler.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.ts
@@ -3,11 +3,11 @@ import Arbor, { Node } from "./Arbor"
 import NodeCache from "./NodeCache"
 import NodeHandler from "./NodeHandler"
 
-export default class NodeArrayHandler<T extends object> extends NodeHandler<
+export default class NodeArrayHandler<T extends object, K extends object = any> extends NodeHandler<
   T[]
 > {
   constructor(
-    $tree: Arbor,
+    $tree: Arbor<K>,
     $path: Path,
     $value: T[],
     $children = new NodeCache()

--- a/packages/arbor-store/src/NodeHandler.test.ts
+++ b/packages/arbor-store/src/NodeHandler.test.ts
@@ -228,8 +228,8 @@ describe("NodeHandler", () => {
 
       store.root.users[0] = store.root.users[1]
 
-      const node1 = store.root.users[0] as Node<User>
-      const node2 = store.root.users[1] as Node<User>
+      const node1 = store.root.users[0]
+      const node2 = store.root.users[1]
 
       expect(store.root.users).toEqual([{ name: "User 2" }, { name: "User 2" }])
       expect(node1.$path.toString()).toEqual("/users/0")
@@ -469,9 +469,9 @@ describe("NodeHandler", () => {
       ) as Node<State>
 
       expect(node.$unwrap()).toBe(state)
-      expect((node.users as Node<User[]>).$unwrap()).toBe(state.users)
-      expect((node.users[0] as Node<User>).$unwrap()).toBe(state.users[0])
-      expect((node.users[1] as Node<User>).$unwrap()).toBe(state.users[1])
+      expect(node.users.$unwrap()).toBe(state.users)
+      expect(node.users[0].$unwrap()).toBe(state.users[0])
+      expect(node.users[1].$unwrap()).toBe(state.users[1])
     })
   })
 
@@ -492,9 +492,9 @@ describe("NodeHandler", () => {
       ) as Node<State>
 
       expect(node.$path.toString()).toEqual("/")
-      expect((node.users as Node<User[]>).$path.toString()).toEqual("/users")
-      expect((node.users[0] as Node<User>).$path.toString()).toEqual("/users/0")
-      expect((node.users[1] as Node<User>).$path.toString()).toEqual("/users/1")
+      expect(node.users.$path.toString()).toEqual("/users")
+      expect(node.users[0].$path.toString()).toEqual("/users/0")
+      expect(node.users[1].$path.toString()).toEqual("/users/1")
     })
   })
 

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -20,9 +20,9 @@ function memoizedFunctionBoundToProxy<T extends object>(target: T, prop: string,
   return Reflect.get(target, boundPropName, proxy)
 }
 
-export default class NodeHandler<T extends object> implements ProxyHandler<T> {
+export default class NodeHandler<T extends object, K extends object = any> implements ProxyHandler<T> {
   constructor(
-    public readonly $tree: Arbor,
+    public readonly $tree: Arbor<K>,
     protected readonly $path: Path,
     protected readonly $value: T,
     readonly $children = new NodeCache()

--- a/packages/arbor-store/src/isNode.test.ts
+++ b/packages/arbor-store/src/isNode.test.ts
@@ -1,11 +1,14 @@
+import Path from "./Path"
 import isNode from "./isNode"
 
 describe("isNode", () => {
   it("checks whether or not a given value is an Arbor Node", () => {
+    expect(isNode({})).toEqual(false)
     expect(isNode(null)).toEqual(false)
     expect(isNode(undefined)).toEqual(false)
-    expect(isNode({})).toEqual(false)
     expect(isNode({ $unwrap: "not a function" })).toEqual(false)
-    expect(isNode({ $unwrap() {} })).toEqual(true)
+    expect(isNode({ $unwrap() {}, $path: "Not an instance of Path" })).toEqual(false)
+
+    expect(isNode({ $unwrap() {}, $path: Path.root })).toEqual(true)
   })
 })

--- a/packages/arbor-store/src/isNode.ts
+++ b/packages/arbor-store/src/isNode.ts
@@ -1,6 +1,7 @@
 import { Node } from "./Arbor"
+import Path from "./Path"
 
 export default function isNode<T extends object>(value: any): value is Node<T> {
-  const isNodeValue = value as Node<T>
-  return typeof isNodeValue?.$unwrap === "function"
+  const node = value as Node<T>
+  return typeof node?.$unwrap === "function" && node?.$path instanceof Path
 }

--- a/packages/arbor-store/src/stitch.test.ts
+++ b/packages/arbor-store/src/stitch.test.ts
@@ -1,4 +1,4 @@
-import Arbor from "./Arbor"
+import Arbor, { ArrayNode } from "./Arbor"
 import stitch from "./stitch"
 
 type User = {
@@ -83,7 +83,7 @@ describe("stitch", () => {
       })
     })
 
-    appStore.root.posts = [{ content: "A new post" }]
+    appStore.root.posts = [{ content: "A new post" }] as ArrayNode<Post>
   })
 
   it("restores deleted root keys when underlying store is updated", () => {

--- a/packages/arbor-store/src/stitch.ts
+++ b/packages/arbor-store/src/stitch.ts
@@ -88,7 +88,7 @@ function subscribeToUnderlyingStoreUpdates<T extends object>(
  * ```
  */
 export type Descriptor = {
-  [key: string]: Arbor<object>
+  [key: string]: Arbor<any>
 }
 
 /**


### PR DESCRIPTION
Arbor will now properly type properties of a state tree node depending on whether they should also be marge as tree nodes. For instance, given the following state tree:

```ts
interface Deep {
  property: number
}

interface Some {
  deep: Deep
}


interface State {
  some: Deep
}

const tree = new Arbor<State>({
  some: {
    deep: {
      property: 123
    }
  }
})
```

Then the following typings are true:

```ts
const root: Node<State> = tree.root
const some: Node<Some> = tree.root.some
const deep: Node<Deep> = tree.root.some.deep
```

Meaning that all of the Arbor Node API will be available to each of these variables, e.g.:

```ts
// Access the Node's path within the state tree
deep.$path.toString()
=> "/some/deep"

// Access the wrapped value
const deep: Deep = deep.$unwrap()
```