### PR TITLE
Publish mutation metadata to subscribers

### DIFF
--- a/packages/arbor-react/src/useArbor.ts
+++ b/packages/arbor-react/src/useArbor.ts
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import Arbor, { ArborNode, INode, isNode, MutationEvent, proxiable } from "@arborjs/store"
+import Arbor, {
+  ArborNode,
+  INode,
+  isNode,
+  MutationEvent,
+  proxiable,
+} from "@arborjs/store"
 
 import { watchAnyMutations } from "./watchAnyMutations"
 
-export type Watcher<T extends object> = (target: ArborNode<T>, event: MutationEvent<T>) => boolean
+export type Watcher<T extends object> = (
+  target: ArborNode<T>,
+  event: MutationEvent<T>
+) => boolean
 
 /**
  * This hook binds a React component to a given Arbor store.
@@ -44,7 +53,7 @@ export type Watcher<T extends object> = (target: ArborNode<T>, event: MutationEv
  */
 export default function useArbor<T extends object>(
   target: Arbor<T> | ArborNode<T> | T,
-  watcher: Watcher<T> = watchAnyMutations(),
+  watcher: Watcher<T> = watchAnyMutations()
 ) {
   if (!(target instanceof Arbor) && !isNode(target) && !proxiable(target)) {
     throw new Error(
@@ -72,21 +81,28 @@ export default function useArbor<T extends object>(
 
   const [state, setState] = useState(node)
 
-  const update = useCallback((event: MutationEvent<T>) => {
-    const nextState = store.getNodeAt(targetPath) as INode<T>
+  const update = useCallback(
+    (event: MutationEvent<T>) => {
+      const nextState = store.getNodeAt(targetPath) as INode<T>
 
-    if (nextState !== state && watcher(state, event)) {
-      setState(nextState)
-    }
-  }, [state, store, targetPath, watcher])
+      if (nextState !== state && watcher(state, event)) {
+        setState(nextState)
+      }
+    },
+    [state, store, targetPath, watcher]
+  )
 
   useEffect(() => {
     update({
       mutationPath: state.$path,
+      metadata: {
+        operation: "set",
+        props: [],
+      },
       state: {
         current: state,
         previous: state,
-      }
+      },
     })
 
     return store.subscribeTo(state as ArborNode<T>, update)

--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -144,6 +144,10 @@ describe("Arbor", () => {
 
       expect(subscriber1).toHaveBeenCalledWith({
         mutationPath: Path.root,
+        metadata: {
+          operation: "set",
+          props: [],
+        },
         state: {
           current: newRoot,
           previous: initialState,
@@ -152,6 +156,10 @@ describe("Arbor", () => {
 
       expect(subscriber2).toHaveBeenCalledWith({
         mutationPath: Path.root,
+        metadata: {
+          operation: "set",
+          props: [],
+        },
         state: {
           current: newRoot,
           previous: initialState,
@@ -235,6 +243,10 @@ describe("Arbor", () => {
 
       expect(subscriber1).toHaveBeenCalledWith({
         mutationPath: Path.parse("/users/0"),
+        metadata: {
+          operation: "set",
+          props: ["name"],
+        },
         state: {
           current: store.root,
           previous: initialState,
@@ -243,6 +255,10 @@ describe("Arbor", () => {
 
       expect(subscriber2).toHaveBeenCalledWith({
         mutationPath: Path.parse("/users/0"),
+        metadata: {
+          operation: "set",
+          props: ["name"],
+        },
         state: {
           current: store.root,
           previous: initialState,
@@ -333,6 +349,10 @@ describe("Arbor", () => {
       expect(subscriber2).not.toHaveBeenCalled()
       expect(subscriber1).toHaveBeenCalledWith({
         mutationPath: Path.parse("/users/0/posts/1"),
+        metadata: {
+          operation: "set",
+          props: ["content"],
+        },
         state: {
           previous: initialState,
           current: store.root,
@@ -341,6 +361,10 @@ describe("Arbor", () => {
 
       expect(subscriber3).toHaveBeenCalledWith({
         mutationPath: Path.parse("/users/0/posts/1"),
+        metadata: {
+          operation: "set",
+          props: ["content"],
+        },
         state: {
           previous: initialState,
           current: store.root,
@@ -352,6 +376,10 @@ describe("Arbor", () => {
       expect(subscriber2).not.toHaveBeenCalled()
       expect(subscriber1).toHaveBeenCalledWith({
         mutationPath: Path.parse("/users/0/posts/1"),
+        metadata: {
+          operation: "set",
+          props: ["content"],
+        },
         state: {
           previous: firstUpdateExpectedState,
           current: store.root,
@@ -360,6 +388,10 @@ describe("Arbor", () => {
 
       expect(subscriber3).toHaveBeenCalledWith({
         mutationPath: Path.parse("/users/0/posts/1"),
+        metadata: {
+          operation: "set",
+          props: ["content"],
+        },
         state: {
           previous: firstUpdateExpectedState,
           current: store.root,

--- a/packages/arbor-store/src/NodeArrayHandler.test.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.test.ts
@@ -13,7 +13,7 @@ interface User {
 }
 
 describe("NodeArrayHandler", () => {
-  it("holds wraps array valus", () => {
+  it("holds wraps array values", () => {
     const state = [{ name: "User 1", address: { street: "Street 1" } }]
     const tree = new Arbor<User[]>(state)
     const node = new Proxy(
@@ -171,6 +171,29 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root[1].address)).toBe(state[2].address)
     })
 
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      delete tree.root[1]
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "delete",
+          props: ["1"],
+        },
+      })
+    })
+
     describe("mode = 'forgiven'", () => {
       it("propates mutation side-effects to the original node's underlying value", () => {
         const state = [
@@ -283,6 +306,33 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root[1].address)).not.toBe(state[2].address)
     })
 
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+        { name: "User 3", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.splice(1, 2, {
+        name: "User 4",
+        address: { street: "Street 4" },
+      })
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "splice",
+          props: ["1", "2"],
+        },
+      })
+    })
+
     describe("mode = 'forgiven'", () => {
       it("propates mutation side-effects to the original node's underlying value", () => {
         const state = [
@@ -373,6 +423,26 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root)).not.toBe(state)
       expect(unwrap(tree.root[0])).toBe(state[0])
       expect(unwrap(tree.root[0].address)).toBe(state[0].address)
+    })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [{ name: "User 1", address: { street: "Street 1" } }]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.push({ name: "User 2", address: { street: "Street 2" } })
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "push",
+          props: ["1"],
+        },
+      })
     })
 
     describe("mode = 'forgiven'", () => {
@@ -518,6 +588,29 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root[2].address)).toBe(state[0].address)
     })
 
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.reverse()
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "reverse",
+          props: [],
+        },
+      })
+    })
+
     describe("mode = 'forgiven'", () => {
       it("propates mutation side-effects to the original node's underlying value", () => {
         const state = [
@@ -646,6 +739,29 @@ describe("NodeArrayHandler", () => {
       expect(tree.root[1]).toBe(user2)
     })
 
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.pop()
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "pop",
+          props: ["1"],
+        },
+      })
+    })
+
     describe("mode = 'forgiven'", () => {
       it("propates mutation side-effects to the original node's underlying value", () => {
         const state = [
@@ -750,6 +866,29 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root[0].address)).toBe(state[1].address)
       expect(unwrap(tree.root[1])).toBe(state[2])
       expect(unwrap(tree.root[1].address)).toBe(state[2].address)
+    })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.shift()
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "shift",
+          props: [],
+        },
+      })
     })
 
     describe("mode = 'forgiven'", () => {
@@ -871,6 +1010,29 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root[2].address)).toBe(state[1].address)
     })
 
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.sort()
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "sort",
+          props: [],
+        },
+      })
+    })
+
     describe("mode = 'forgiven'", () => {
       it("propates mutation side-effects to the original node's underlying value", () => {
         const state = [
@@ -907,7 +1069,7 @@ describe("NodeArrayHandler", () => {
     })
   })
 
-  describe("FOCUS #unshift", () => {
+  describe("#unshift", () => {
     it("generates a new state tree root node", () => {
       const state = [{ name: "User 3", address: { street: "Street 3" } }]
 
@@ -966,6 +1128,32 @@ describe("NodeArrayHandler", () => {
       expect(unwrap(tree.root)).not.toBe(state)
       expect(unwrap(tree.root[2])).toBe(state[0])
       expect(unwrap(tree.root[2].address)).toBe(state[0].address)
+    })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = [
+        { name: "User 1", address: { street: "Street 1" } },
+        { name: "User 2", address: { street: "Street 2" } },
+      ]
+
+      const tree = new Arbor<User[]>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.unshift(
+        { name: "User 3", address: { street: "Street 1" } },
+        { name: "User 4", address: { street: "Street 2" } }
+      )
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/"),
+        metadata: {
+          operation: "unshift",
+          props: ["0", "1"],
+        },
+      })
     })
 
     describe("mode = 'forgiven'", () => {

--- a/packages/arbor-store/src/NodeArrayHandler.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.ts
@@ -6,7 +6,17 @@ export default class NodeArrayHandler<
   K extends object
 > extends NodeHandler<T[], K> {
   deleteProperty(_target: T[], prop: string): boolean {
-    this.splice(parseInt(prop, 10), 1)
+    this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
+      node.splice(parseInt(prop, 10), 1)
+
+      return {
+        operation: "delete",
+        props: [prop],
+      }
+    })
+
+    this.$children.reset()
+
     return true
   }
 
@@ -15,6 +25,11 @@ export default class NodeArrayHandler<
 
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       size = node.push(...item)
+
+      return {
+        operation: "push",
+        props: [String(size - 1)],
+      }
     })
 
     return size
@@ -23,6 +38,11 @@ export default class NodeArrayHandler<
   reverse() {
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       node.reverse()
+
+      return {
+        operation: "reverse",
+        props: [],
+      }
     })
 
     this.$children.reset()
@@ -34,7 +54,13 @@ export default class NodeArrayHandler<
     let popped: T
 
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
+      const poppedIndex = node.length - 1
       popped = node.pop()
+
+      return {
+        operation: "pop",
+        props: [String(poppedIndex)],
+      }
     })
 
     this.$children.delete(popped)
@@ -47,6 +73,11 @@ export default class NodeArrayHandler<
 
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       shifted = node.shift()
+
+      return {
+        operation: "shift",
+        props: [],
+      }
     })
 
     this.$children.reset()
@@ -57,6 +88,11 @@ export default class NodeArrayHandler<
   sort(compareFn: (a: T, b: T) => number): T[] {
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       node.sort(compareFn)
+
+      return {
+        operation: "sort",
+        props: [],
+      }
     })
 
     this.$children.reset()
@@ -69,6 +105,13 @@ export default class NodeArrayHandler<
 
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       deleted = node.splice(start, deleteCount, ...items)
+
+      return {
+        operation: "splice",
+        props: Array(deleteCount)
+          .fill(0)
+          .map((_, i) => String(start + i)),
+      }
     })
 
     this.$children.reset()
@@ -81,6 +124,11 @@ export default class NodeArrayHandler<
 
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       size = node.unshift(...items)
+
+      return {
+        operation: "unshift",
+        props: items.map((_, i) => String(i)),
+      }
     })
 
     this.$children.reset()

--- a/packages/arbor-store/src/NodeHandler.test.ts
+++ b/packages/arbor-store/src/NodeHandler.test.ts
@@ -299,6 +299,28 @@ describe("NodeHandler", () => {
         })
       })
     })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = {
+        users: [{ name: "User 1", address: { street: "Street 1" } }],
+      }
+
+      const tree = new Arbor<State>(state)
+
+      tree.subscribe(subscriber)
+
+      tree.root.users[0].name = "User Updated"
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/users/0"),
+        metadata: {
+          operation: "set",
+          props: ["name"],
+        },
+      })
+    })
   })
 
   describe("delete trap", () => {
@@ -395,6 +417,31 @@ describe("NodeHandler", () => {
       const nodeChildren = children(tree.root.users[0])
 
       expect(nodeChildren.has(state.users[0].address)).toBe(false)
+    })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const subscriber = jest.fn()
+      const state = {
+        users: [
+          { name: "User 1", address: { street: "Street 1" } },
+          { name: "User 2", address: { street: "Street 2" } },
+        ],
+      }
+
+      const tree = new Arbor<State>(state)
+
+      tree.subscribe(subscriber)
+
+      delete tree.root.users[0].name
+
+      expect(subscriber).toHaveBeenCalledWith({
+        state: { current: tree.root, previous: state },
+        mutationPath: Path.parse("/users/0"),
+        metadata: {
+          operation: "delete",
+          props: ["name"],
+        },
+      })
     })
 
     describe("mode = 'forgiven'", () => {

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -88,6 +88,11 @@ export default class NodeHandler<T extends object, K extends object>
 
     this.$tree.mutate(proxy, (t: T) => {
       t[prop] = value
+
+      return {
+        operation: "set",
+        props: [prop],
+      }
     })
 
     return true
@@ -99,6 +104,11 @@ export default class NodeHandler<T extends object, K extends object>
     if (prop in target) {
       this.$tree.mutate(this as unknown as INode<T>, (t: T) => {
         delete t[prop]
+
+        return {
+          operation: "delete",
+          props: [prop],
+        }
       })
 
       this.$children.delete(childValue)

--- a/packages/arbor-store/src/Subscribers.test.ts
+++ b/packages/arbor-store/src/Subscribers.test.ts
@@ -8,6 +8,7 @@ describe("Subscribers", () => {
     const subscribers = new Subscribers()
     const mutationEvent = {
       mutationPath: Path.root,
+      metadata: { operation: "", props: [] },
       state: { previous: { count: 1 }, current: { count: 2 } },
     }
 
@@ -26,6 +27,7 @@ describe("Subscribers", () => {
     const subscribers = new Subscribers()
     const mutationEvent = {
       mutationPath: Path.root,
+      metadata: { operation: "", props: [] },
       state: { previous: { count: 1 }, current: { count: 2 } },
     }
 

--- a/packages/arbor-store/src/Subscribers.ts
+++ b/packages/arbor-store/src/Subscribers.ts
@@ -1,4 +1,4 @@
-import { MutationMetadata } from "mutate"
+import { MutationMetadata } from "./mutate"
 import Path from "./Path"
 
 /**

--- a/packages/arbor-store/src/Subscribers.ts
+++ b/packages/arbor-store/src/Subscribers.ts
@@ -1,3 +1,4 @@
+import { MutationMetadata } from "mutate"
 import Path from "./Path"
 
 /**
@@ -11,6 +12,7 @@ export type Unsubscribe = () => void
 export type MutationEvent<T> = {
   state: { current?: T; previous?: T }
   mutationPath: Path
+  metadata: MutationMetadata
 }
 
 /**

--- a/packages/arbor-store/src/mutate.test.ts
+++ b/packages/arbor-store/src/mutate.test.ts
@@ -36,7 +36,7 @@ describe("mutate", () => {
     const book = node.author.books[0]
 
     const path = Path.parse("/author/address")
-    const copy = mutate<State, Address>(node, path, (a) => {
+    const { root: copy } = mutate<State, Address>(node, path, (a) => {
       a.street = "Some other street"
     })
 

--- a/packages/arbor-store/src/mutate.ts
+++ b/packages/arbor-store/src/mutate.ts
@@ -1,10 +1,15 @@
 import Path from "./Path"
 import type { INode } from "./Arbor"
 
+export type MutationMetadata = {
+  operation?: string
+  props: string[]
+}
+
 /**
  * A mutation function used to update an Arbor tree node.
  */
-export type Mutation<T extends object> = (arg0: T) => void
+export type Mutation<T extends object> = (arg0: T) => void | MutationMetadata
 
 /**
  * Mutates a given node by traversing the given path and applying the
@@ -19,7 +24,7 @@ export default function mutate<T extends object, K extends object>(
   node: INode<T>,
   path: Path,
   mutation: Mutation<K>
-): INode<T> {
+) {
   try {
     const root = node.$clone()
 
@@ -39,9 +44,12 @@ export default function mutate<T extends object, K extends object>(
       return childNodeCopy
     }, root)
 
-    mutation(targetNode.$unwrap() as unknown as K)
+    const metadata = mutation(targetNode.$unwrap() as unknown as K)
 
-    return root
+    return {
+      root,
+      metadata,
+    }
   } catch (e) {
     return undefined
   }


### PR DESCRIPTION
Mutation metadata can be used by subscribers to determine exactly what the mutation was, enabling use cases like granular synchronization between local and remote stores, time-travel debug, etc...

Example:

```ts
interface User {
  name: string
  age: number
}

const store = new Arbor({
  users: [
    { name: "Bob", age: 30 },
    { name: "Alice", age: 35 },
  ]
})

store.subscribe(({ mutationPath, metadata }) => {
  console.log(mutationPath.toString(), ":", metadata)
})

store.root.users.push({ name: "Carol", 28 })
=> /users : { operation: "push", props: ["2"] }

delete store.root.users[0]
=> /users : { operation: "delete", props: ["0"] }

delete store.root.users[0].age++
=> /users/0 : { operation: "set", props: ["age"] }
```