### PR TITLE
BaseNode improvements

### DIFF
--- a/packages/arbor-store/src/BaseNode.test.ts
+++ b/packages/arbor-store/src/BaseNode.test.ts
@@ -40,6 +40,25 @@ describe("BaseNode", () => {
 
       expect(() => todo.detach()).toThrowError(NotAnArborNodeError)
     })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const todo = Todo.from<Todo>({
+        uuid: "abc",
+        text: "Do the dishes",
+        completed: false,
+      })
+
+      const store = new Arbor({
+        todoId: todo,
+      })
+
+      store.subscribe((event) => {
+        expect(event.metadata.operation).toBe("delete")
+        expect(event.metadata.props).toEqual(["todoId"])
+      })
+
+      store.root.todoId.detach()
+    })
   })
 
   describe("#parent", () => {
@@ -116,6 +135,28 @@ describe("BaseNode", () => {
 
       expect(() => todo.attach()).toThrowError(NotAnArborNodeError)
     })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const todo = Todo.from<Todo>({
+        uuid: "abc",
+        text: "Do the dishes",
+        completed: false,
+      })
+
+      const store = new Arbor({
+        todoId: todo,
+      })
+
+      const node = store.root.todoId
+      node.detach()
+
+      store.subscribe((event) => {
+        expect(event.metadata.operation).toBe("attach")
+        expect(event.metadata.props).toEqual(["todoId"])
+      })
+
+      node.attach()
+    })
   })
 
   describe("#merge", () => {
@@ -157,6 +198,28 @@ describe("BaseNode", () => {
       const todo = new Todo()
 
       expect(() => todo.merge({})).toThrowError(NotAnArborNodeError)
+    })
+
+    it("publishes mutation metadata to subscribers", () => {
+      const todo = Todo.from<Todo>({
+        uuid: "abc",
+        text: "Do the dishes",
+        completed: false,
+      })
+
+      const store = new Arbor({
+        todoId: todo,
+      })
+
+      store.subscribe((event) => {
+        expect(event.metadata.operation).toBe("merge")
+        expect(event.metadata.props).toEqual(["text", "completed"])
+      })
+
+      store.root.todoId.merge({
+        text: "New Todo",
+        completed: true,
+      })
     })
   })
 

--- a/packages/arbor-store/src/BaseNode.test.ts
+++ b/packages/arbor-store/src/BaseNode.test.ts
@@ -1,7 +1,7 @@
 import Arbor from "./Arbor"
 import BaseNode from "./BaseNode"
 import Collection from "./Collection"
-import { NotAnArborNodeError } from "./errors"
+import { ArborError, NotAnArborNodeError } from "./errors"
 
 describe("BaseNode", () => {
   class Todo extends BaseNode<Todo> {
@@ -39,6 +39,18 @@ describe("BaseNode", () => {
       const todo = new Todo()
 
       expect(() => todo.detach()).toThrowError(NotAnArborNodeError)
+    })
+
+    it("throws an error when trying to detach root node", () => {
+      const todo = Todo.from<Todo>({
+        uuid: "abc",
+        text: "Do the dishes",
+        completed: false,
+      })
+
+      const store = new Arbor(todo)
+
+      expect(() => store.root.detach()).toThrowError(ArborError)
     })
 
     it("publishes mutation metadata to subscribers", () => {

--- a/packages/arbor-store/src/BaseNode.ts
+++ b/packages/arbor-store/src/BaseNode.ts
@@ -42,6 +42,10 @@ export default class BaseNode<T extends object> {
     const id = node.$path.props[node.$path.props.length - 1]
     node.$tree.mutate(parentPath, (parent) => {
       parent[id] = node.$unwrap()
+      return {
+        operation: "attach",
+        props: [id],
+      }
     })
 
     return node.$tree.getNodeAt(node.$path)
@@ -52,6 +56,10 @@ export default class BaseNode<T extends object> {
 
     this.$tree.mutate(this, (value) => {
       Object.assign(value, attributes)
+      return {
+        operation: "merge",
+        props: Object.keys(attributes),
+      }
     })
 
     return this.$tree.getNodeAt(this.$path)

--- a/packages/arbor-store/src/BaseNode.ts
+++ b/packages/arbor-store/src/BaseNode.ts
@@ -1,6 +1,6 @@
 import isNode from "./isNode"
 import { ArborProxy } from "./proxiable"
-import { NotAnArborNodeError } from "./errors"
+import { ArborError, NotAnArborNodeError } from "./errors"
 
 import type { AttributesOf, INode } from "./Arbor"
 
@@ -29,6 +29,8 @@ export default class BaseNode<T extends object> {
   detach() {
     const node = this
     if (!isNode(node)) throw new NotAnArborNodeError()
+    if (node.$path.isRoot())
+      throw new ArborError("Cannot detach store's root node")
 
     const id = node.$path.props[node.$path.props.length - 1]
     delete this.parent()[id]

--- a/packages/arbor-store/src/Path.test.ts
+++ b/packages/arbor-store/src/Path.test.ts
@@ -26,6 +26,14 @@ describe("Path", () => {
     })
   })
 
+  describe("#isRoot", () => {
+    it("checks if a path points to the root of a state tree", () => {
+      expect(Path.parse("").isRoot()).toBe(true)
+      expect(Path.parse("/").isRoot()).toBe(true)
+      expect(Path.parse("/users").isRoot()).toBe(false)
+    })
+  })
+
   describe("#parent", () => {
     it("returns the parent path", () => {
       const path = new Path("users", "0")

--- a/packages/arbor-store/src/Path.ts
+++ b/packages/arbor-store/src/Path.ts
@@ -153,6 +153,15 @@ export default class Path {
     return `/${this.props.join("/")}`
   }
 
+  /**
+   * Checks if the path points to the root of a state tree.
+   *
+   * @returns true if the path points to the root of a state tree, false otherwise.
+   */
+  isRoot() {
+    return this.props.length === 0
+  }
+
   get [Symbol.toStringTag]() {
     return this.toString()
   }


### PR DESCRIPTION
1. Publish mutation metadata;
2. Prevent detaching state tree root nodes.