### PR TITLE
Arbor plugins: lazy load dependencies

### DIFF
--- a/examples/react-todo/src/store/useNewTodo.ts
+++ b/examples/react-todo/src/store/useNewTodo.ts
@@ -1,6 +1,7 @@
 import Arbor from "@arborjs/store"
 import useArbor from "@arborjs/react"
-import { Logger, LocalStorage } from "@arborjs/plugins"
+import Logger from "@arborjs/plugins/Logger"
+import LocalStorage from "@arborjs/plugins/LocalStorage"
 
 export interface Input {
   value: string

--- a/examples/react-todo/src/store/useTodos.ts
+++ b/examples/react-todo/src/store/useTodos.ts
@@ -1,4 +1,5 @@
-import { Logger, LocalStorage } from "@arborjs/plugins"
+import Logger from "@arborjs/plugins/Logger"
+import LocalStorage from "@arborjs/plugins/LocalStorage"
 import useArbor, { watchChildrenProps } from "@arborjs/react"
 import Arbor, { BaseNode, Collection } from "@arborjs/store"
 import { v4 as uuid } from "uuid"

--- a/examples/react-todo/src/store/useTodosFilter.ts
+++ b/examples/react-todo/src/store/useTodosFilter.ts
@@ -1,5 +1,6 @@
 import useArbor from "@arborjs/react"
-import { Logger, LocalStorage } from "@arborjs/plugins"
+import Logger from "@arborjs/plugins/Logger"
+import LocalStorage from "@arborjs/plugins/LocalStorage"
 import Arbor, { Collection } from "@arborjs/store"
 
 import { Todo } from "./useTodos"

--- a/packages/arbor-plugins/package.json
+++ b/packages/arbor-plugins/package.json
@@ -63,9 +63,26 @@
     "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest --passWithNoTests",
     "dev": "jest --watch",
-    "build": "yarn clean && NODE_ENV=production node ../../tools/build.js && yarn tsc",
-    "build:dev": "yarn clean && NODE_ENV=development node ../../tools/build.js && yarn tsc",
+    "build": "yarn clean && NODE_ENV=production ENTRYPOINTS=IndexedDB.ts,LocalStorage.ts,Logger.ts node ../../tools/build.js && yarn tsc",
+    "build:dev": "yarn clean && NODE_ENV=development ENTRYPOINTS=IndexedDB.ts,LocalStorage.ts,Logger.ts node ../../tools/build.js && yarn tsc",
     "prepublish": "yarn build",
     "publish": "np"
+  },
+  "exports": {
+    "./Logger": {
+      "import": "./dist/Logger.esm.js",
+      "require": "./dist/Logger.cjs.js",
+      "default": "./dist/Logger.mjs"
+    },
+    "./LocalStorage": {
+      "import": "./dist/LocalStorage.esm.js",
+      "require": "./dist/LocalStorage.cjs.js",
+      "default": "./dist/LocalStorage.mjs"
+    },
+    "./idb": {
+      "import": "./dist/IndexedDB.esm.js",
+      "require": "./dist/IndexedDB.cjs.js",
+      "default": "./dist/IndexedDB.mjs"
+    }
   }
 }

--- a/packages/arbor-plugins/src/IndexedDB.ts
+++ b/packages/arbor-plugins/src/IndexedDB.ts
@@ -1,5 +1,5 @@
 import Arbor, { INode, Plugin } from "@arborjs/store"
-import { IDBPDatabase, openDB, OpenDBCallbacks } from "idb"
+import type { IDBPDatabase, OpenDBCallbacks } from "idb"
 
 export type Config<T extends object> = OpenDBCallbacks<T> & {
   name: string
@@ -12,6 +12,7 @@ export default class IndexedDB<T extends object> implements Plugin<T> {
   constructor(readonly config: Config<T>) {}
 
   async configure(store: Arbor<T>) {
+    const { openDB } = await import("idb")
     const db = await openDB(this.config.name, this.config.version, this.config)
     const initialState = await this.config.load(db)
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -11,10 +11,15 @@ const {
   peerDependencies = {},
 } = require(`${cwd}/package.json`)
 
+const entrypoints = (process.env.ENTRYPOINTS || "index.ts")
+  .split(",")
+  .map((fileName) => `${src}/${fileName}`)
+
 const config = {
-  entryPoints: [`${src}/index.ts`],
+  entryPoints: entrypoints,
   bundle: true,
   minify: isProduction,
+  outdir: dist,
   external: Object.keys(dependencies).concat(Object.keys(peerDependencies)),
   define: {
     "global.DEBUG": !isProduction,
@@ -24,17 +29,20 @@ const config = {
 build({
   ...config,
   format: "cjs",
-  outfile: `${dist}/index.cjs.js`,
+  outbase: src,
+  entryNames: "[dir]/[name].cjs",
 })
 
 build({
   ...config,
-  outfile: `${dist}/index.esm.js`,
   format: "esm",
+  outbase: src,
+  entryNames: "[dir]/[name].esm",
 })
 
 build({
   ...config,
-  outfile: `${dist}/index.mjs`,
   format: "esm",
+  outbase: src,
+  entryNames: "[dir]/[name].mjs",
 })


### PR DESCRIPTION
1. Provide a direct import path to plugins via exports definitions;
2. Lazy load import `idb` to avoid client bundles from inheriting that dep even though they may not be using the `IndexedDB` plugin.