### PR TITLE
Improve collections API

### DIFF
--- a/packages/arbor-store/src/Collection.test.ts
+++ b/packages/arbor-store/src/Collection.test.ts
@@ -40,6 +40,15 @@ describe("Collection", () => {
       ).toThrowError(NotAnArborNodeError)
     })
 
+    it("skips items whose UUID already exists in the collection", () => {
+      const store = new Arbor(new Collection<User>({ uuid: "abc", name: "Bob" }))
+      const bob = store.root.fetch("abc")
+
+      const result = store.root.push({ uuid: "abc", name: "Bob is already in the collection" })
+
+      expect(result).toBe(bob)
+    })
+
     it("pushes many items into the collection", () => {
       const user1 = { uuid: "abc", name: "Bob" }
       const user2 = { uuid: "bcd", name: "Alice" }

--- a/packages/arbor-store/src/Collection.test.ts
+++ b/packages/arbor-store/src/Collection.test.ts
@@ -1,9 +1,11 @@
+/* eslint-disable max-classes-per-file */
 import Arbor, { ArborNode } from "./Arbor"
 import Collection from "./Collection"
 import { MissingUUIDError, NotAnArborNodeError } from "./errors"
 
 import type { INode } from "./Arbor"
 import { toINode } from "./test.helpers"
+import BaseNode from "./BaseNode"
 
 interface User {
   uuid: string
@@ -155,6 +157,20 @@ describe("Collection", () => {
         name: "Updated Bob",
       })
     })
+
+    it("preserves item's prototype", () => {
+      class User extends BaseNode<User> {
+        uuid: string
+        name: string
+      }
+
+      const user1 = User.from<User>({ uuid: "abc", name: "Alice" })
+      const store = new Arbor(new Collection<User>(user1))
+
+      const alice = store.root.merge("abc", { name: "Alice Doe" })
+
+      expect(alice).toBeInstanceOf(User)
+    })
   })
 
   describe("#mergeBy", () => {
@@ -244,6 +260,26 @@ describe("Collection", () => {
         () => true,
         (user) => ({ name: `${user.name} Updated` })
       )
+    })
+
+    it("preserves item's prototype", () => {
+      class User extends BaseNode<User> {
+        uuid: string
+        name: string
+      }
+
+      const user1 = User.from<User>({ uuid: "abc", name: "Alice" })
+      const user2 = User.from<User>({ uuid: "bcd", name: "Bob" })
+      const user3 = User.from<User>({ uuid: "efg", name: "Aline" })
+      const store = new Arbor(new Collection<User>(user1, user2, user3))
+
+      const users = store.root.mergeBy(
+        user => user.name.startsWith("Ali"),
+        user => ({ name: `${user.name} Updated` })
+      )
+
+      expect(users[0]).toBeInstanceOf(User)
+      expect(users[1]).toBeInstanceOf(User)
     })
   })
 

--- a/packages/arbor-store/src/Collection.ts
+++ b/packages/arbor-store/src/Collection.ts
@@ -122,10 +122,9 @@ export default class Collection<T extends Item> {
     node.$tree.mutate<Collection<T>>(
       node as INode<Collection<T>>,
       (collection) => {
-        collection[item.uuid] = {
-          ...item,
+        collection[item.uuid] = clone(item, {
           ...data,
-        }
+        })
 
         return {
           operation: "merge",
@@ -150,12 +149,10 @@ export default class Collection<T extends Item> {
       (collection) => {
         Object.values(collection).forEach((value) => {
           if (predicate(value)) {
-            const newValue = {
-              ...value,
-              ...updateFn(value),
-            }
+            collection[value.uuid] = clone(value, {
+              ...updateFn(value)
+            })
 
-            collection[value.uuid] = newValue
             affectedUUIDs.push(value.uuid)
           }
         })


### PR DESCRIPTION
Fixes a few shortcomings in the Collections API.

### Future Work

1. The current implementation presents a few limitations, for instance, keeping track of items as properties in the collection itself causes issues when one decides to extend the Collection class with new properties, in that case, the new properties will be considered to be Collection items, incorrectly.
2. Code-splitting might be trickier since the entire API is part of the class. Perhaps a module-based API would work better?

#### Module-based API Sketch

```ts
/**
 * Any object compatible with the Item interface can be used as a Collection item
 */
interface Item {
  uuid: string
}

/**
 * A simple key-value store for Item records
 */
type Collection<T extends Item> = Iterable<T> & {
  [key: string]: T
}

/**
 * Helper function used to create collections.
 */
function createCollection<T extends Item>(...items): Collection<T> {
  return {
    *[Symbol.iterator](): Generator<T, any, undefined> {
      for (const item of Object.values<T>(this)) {
        yield item
      }
    }
  }
}

function push<T extends Item>(collection: AborNode<Collection<T>>, ...items: T[]): ArborNode<T[]>
function delete<T extends Item>(collection: AborNode<Collection<T>>, uuid: string): T
function merge<T extends Item>(collection: AborNode<Collection<T>>, data: Omit<Partial<T>, "uuid">): ArborNode<T>
```