### PR TITLE
Implement dynamic node handling strategy resolution

### DIFF
--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -5,6 +5,7 @@ import Arbor, { MutationMode, INode } from "./Arbor"
 import BaseNode from "./BaseNode"
 import Collection from "./Collection"
 import { warmup } from "./test.helpers"
+import NodeArrayHandler from "./NodeArrayHandler"
 
 describe("Arbor", () => {
   it("correctly updates the store when making sequential updates to a given node", () => {
@@ -536,6 +537,50 @@ describe("Arbor", () => {
       expect(firstTodo.reload()).toEqual(
         Todo.from<Todo>({ text: "Updated content", completed: true })
       )
+    })
+
+    describe("#with", () => {
+      it("allows for custom node proxy handlers", () => {
+        class MyArrayHandler extends NodeArrayHandler {
+          $ids = new Map<number, string>()
+
+          $idFor(index: number) {
+            return this.$ids.get(index)
+          }
+
+          get(target: object[], prop: string, receiver: INode<object[], object[]>) {
+            const index = parseInt(prop, 10)
+
+            if (!Number.isNaN(index) && !this.$ids.has(index)) {
+              this.$ids.set(index, `random-id-${index}`)
+            }
+
+            return super.get(target, prop, receiver)
+          }
+        }
+
+        const store = new Arbor<Todo[]>([])
+
+        // Overrides the default behavior for proxying array values
+        store.with(MyArrayHandler)
+
+        // Initializes the store after registering a new node handler
+        // so that the root node can be proxyied with the correct handler
+        store.setRoot([
+          Todo.from<Todo>({ text: "Walk the dogs" }),
+          Todo.from<Todo>({ text: "Document Arbor" }),
+        ])
+
+        // traverses the tree forcing Arbor to proxy and
+        // cache store.root and store.root[1] nodes
+        store.root[1].text
+        const todos = store.root as any
+
+        // Arbor lazily proxies nodes in the state tree, since store.root[0]
+        // was never proxied no custom $id was generated for that node.
+        expect(todos.$idFor(0)).toBeUndefined()
+        expect(todos.$idFor(1)).toEqual("random-id-1")
+      })
     })
 
     describe("Collection", () => {

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -17,12 +17,12 @@ interface NodeHandlerFactory {
    * Creates a new instance of the node handling strategy.
    */
   new (
-    $tree: Arbor,
+    $tree: Arbor<any>,
     $path: Path,
     $value: any,
     $children: NodeCache,
-    $subscribers: Subscribers
-  ): NodeHandler
+    $subscribers: Subscribers<any>
+  ): NodeHandler<any, any>
 
   /**
    * Checks if the strategy can handle the given value.
@@ -315,6 +315,15 @@ export default class Arbor<T extends object = object> {
     if (!isNode(node)) throw new NotAnArborNodeError()
 
     return node.$subscribers.subscribe(subscriber)
+  }
+
+  /**
+   * Allow extending Arbor's proxying behavior with new node handler implementations.
+   *
+   * @param Factory a list of NodeHandler implementations to register in the store.
+   */
+  with(...Factory: NodeHandlerFactory[]) {
+    this.#factories = [...Factory, ...this.#factories]
   }
 
   /**

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -12,7 +12,7 @@ import { notifyAffectedSubscribers } from "./notifyAffectedSubscribers"
  * Describes a factory capable of creating new instances of a particular NodeHandler
  * strategy used by Arbor for creating proxies for nodes within the state tree.
  */
-interface NodeHandlerFactory {
+export interface NodeHandlerFactory {
   /**
    * Creates a new instance of the node handling strategy.
    */

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -99,6 +99,7 @@ export enum MutationMode {
 
 export type ArborConfig = {
   mode?: MutationMode
+  factories?: NodeHandlerFactory[]
 }
 
 /**
@@ -164,10 +165,10 @@ export default class Arbor<T extends object = object> {
    */
   constructor(
     initialState = {} as T,
-    { mode = MutationMode.STRICT }: ArborConfig = {}
+    { mode = MutationMode.STRICT, factories = [] }: ArborConfig = {}
   ) {
     this.mode = mode
-    this.#factories = [NodeArrayHandler, NodeHandler]
+    this.#factories = [...factories, NodeArrayHandler, NodeHandler]
     this.setRoot(initialState)
   }
 

--- a/packages/arbor-store/src/NodeArrayHandler.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.ts
@@ -2,9 +2,13 @@ import { INode } from "./Arbor"
 import NodeHandler from "./NodeHandler"
 
 export default class NodeArrayHandler<
-  T extends object,
-  K extends object
+  T extends object = object,
+  K extends object = object
 > extends NodeHandler<T[], K> {
+  static accepts(value: any) {
+    return Array.isArray(value)
+  }
+
   deleteProperty(_target: T[], prop: string): boolean {
     this.$tree.mutate(this as unknown as INode<T[]>, (node: T[]) => {
       node.splice(parseInt(prop, 10), 1)

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -26,8 +26,10 @@ function memoizedFunctionBoundToProxy<T extends object>(
   return Reflect.get(target, boundPropName, proxy)
 }
 
-export default class NodeHandler<T extends object, K extends object>
-  implements ProxyHandler<T>
+export default class NodeHandler<
+  T extends object = object,
+  K extends object = object
+> implements ProxyHandler<T>
 {
   constructor(
     readonly $tree: Arbor<K>,
@@ -36,6 +38,10 @@ export default class NodeHandler<T extends object, K extends object>
     readonly $children = new NodeCache(),
     readonly $subscribers = new Subscribers<T>()
   ) {}
+
+  static accepts(_value: any) {
+    return true
+  }
 
   $unwrap(): T {
     return this.$value
@@ -117,7 +123,10 @@ export default class NodeHandler<T extends object, K extends object>
     return true
   }
 
-  private $createChildNode<V extends object>(prop: string, value: V): INode<V> {
+  protected $createChildNode<V extends object>(
+    prop: string,
+    value: V
+  ): INode<V> {
     const childPath = this.$path.child(prop)
     const childNode = this.$tree.createNode(childPath, value)
     return this.$children.set(value, childNode)

--- a/packages/arbor-store/src/Subscribers.ts
+++ b/packages/arbor-store/src/Subscribers.ts
@@ -20,7 +20,7 @@ export type MutationEvent<T> = {
  */
 export type Subscriber<T> = (event: MutationEvent<T>) => void
 
-export default class Subscribers<T extends object> {
+export default class Subscribers<T extends object = object> {
   constructor(private readonly subscribers: Set<Subscriber<T>> = new Set()) {}
 
   subscribe(subscriber: Subscriber<T>): Unsubscribe {

--- a/packages/arbor-store/src/index.ts
+++ b/packages/arbor-store/src/index.ts
@@ -3,6 +3,10 @@ export { default as Path } from "./Path"
 export { default as clone } from "./clone"
 export { default as isNode } from "./isNode"
 export { default as BaseNode } from "./BaseNode"
+export { default as NodeCache } from "./NodeCache"
+export { default as Subscribers } from "./Subscribers"
+export { default as NodeHandler } from "./NodeHandler"
+export { default as NodeArrayHandler } from "./NodeArrayHandler"
 export { default as Collection } from "./Collection"
 export { default as isClonable } from "./isClonable"
 export { default as proxiable, ArborProxy } from "./proxiable"
@@ -16,5 +20,6 @@ export type {
   ArborNode,
   AttributesOf,
   INode,
+  NodeHandlerFactory,
   Plugin,
 } from "./Arbor"


### PR DESCRIPTION
resolves #72 

This PR changes the node handling strategy resolution to a more dynamic behavior which will allow users to extend Arbor with specific node handling strategies.