### PR TITLE
Track stale nodes

### DIFF
--- a/.todo
+++ b/.todo
@@ -1,0 +1,10 @@
+☐ Move stale node check into Arbor#mutate so it is centralized
+☐ Throw an error when attempting to mutate a stale node as oppposed to ignoring the mutation
+☐ Tackle code TODOs
+☐ Look for improvement areas around:
+  ☐ readability
+  ☐ abstraction extractions
+  ☐ release process
+  ☐ documentation
+  ☐ spec coverage
+  ☐ streamline specs: they're a bit confusing at the moment

--- a/examples/react-todo/src/store/useTodos.ts
+++ b/examples/react-todo/src/store/useTodos.ts
@@ -1,10 +1,9 @@
-import { v4 as uuid } from "uuid"
-import Logger from "@arborjs/plugins/Logger"
 import LocalStorage from "@arborjs/plugins/LocalStorage"
-import Arbor, { BaseNode, Repository } from "@arborjs/store"
+import Logger from "@arborjs/plugins/Logger"
 import useArbor from "@arborjs/react"
+import Arbor, { BaseNode, Repository } from "@arborjs/store"
+import { v4 as uuid } from "uuid"
 
-import { store as storeFilter } from "./useTodosFilter"
 import { watchTodosFilteredBy } from "./watchers/watchTodosFilteredBy"
 
 export type Status = "completed" | "active"
@@ -61,5 +60,5 @@ store.use(new Logger("[Todos]"))
 store.use(persistence)
 
 export default function useTodos() {
-  return useArbor(store.state, watchTodosFilteredBy(storeFilter.state.value))
+  return useArbor(store.state, watchTodosFilteredBy())
 }

--- a/examples/react-todo/src/store/watchers/watchTodosFilteredBy.ts
+++ b/examples/react-todo/src/store/watchers/watchTodosFilteredBy.ts
@@ -1,10 +1,7 @@
-import { watchChildren, Watcher } from "@arborjs/react";
-import { Repository } from "@arborjs/store";
-import { Todo } from "../useTodos";
+import { watchChildren, Watcher } from "@arborjs/react"
+import { Repository } from "@arborjs/store"
+import { Todo } from "../useTodos"
 
-export const watchTodosFilteredBy = (filter: string): Watcher<Repository<Todo>> => (target, event) => {
-  const isTodoFilterAll = filter === "all";
-
-  return event.mutationPath.targets(target) ||
-    (!isTodoFilterAll && watchChildren<Todo>("status")(target, event));
-};
+export const watchTodosFilteredBy = (): Watcher<Repository<Todo>> => (target, event) => {
+  return event.mutationPath.targets(target) || watchChildren<Repository<Todo>>("status")(target, event)
+}

--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -621,6 +621,45 @@ describe("Arbor", () => {
       })
     })
 
+    it("ignores mutations on stale nodes", () => {
+      const store = new Arbor({
+        users: {
+          a: { name: "Alice" },
+          b: { name: "Bob" },
+          c: { name: "Carol" },
+        }
+      })
+
+      const alice = store.state.users.a
+      store.state.users.a = store.state.users.b
+      expect(store.state.users.a).toEqual({ name: "Bob" })
+
+      // the alice variable at this point, references a node that
+      // no longer exists within the state tree since it was replaced
+      // on line 634.
+      alice.name = "Alice Doe"
+
+      expect(store.state.users.a).toEqual({ name: "Bob" })
+    })
+
+    it("ignores array deletions on stale nodes", () => {
+      const store = new Arbor({
+        users: [
+          { name: "Alice" },
+          { name: "Bob" },
+          { name: "Carol" },
+        ]
+      })
+
+      const alice = store.state.users[0]
+      store.state.users[0] = store.state.users[1]
+      expect(store.state.users[0]).toEqual({ name: "Bob" })
+
+      alice.name = "Alice Doe"
+
+      expect(store.state.users[0]).toEqual({ name: "Bob" })
+    })
+
     describe("Repository", () => {
       it("allows managing Repository of items", () => {
         const store = new Arbor(

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -5,7 +5,7 @@ import NodeCache from "./NodeCache"
 import NodeHandler from "./NodeHandler"
 import NodeArrayHandler from "./NodeArrayHandler"
 import mutate, { Mutation, MutationMetadata } from "./mutate"
-import { NotAnArborNodeError } from "./errors"
+import { NotAnArborNodeError, StaleNodeError } from "./errors"
 import Subscribers, { Subscriber, Unsubscribe } from "./Subscribers"
 import { notifyAffectedSubscribers } from "./notifyAffectedSubscribers"
 import { assignUUID, ArborUUID } from "./uuid"
@@ -210,6 +210,10 @@ export default class Arbor<T extends object = object> {
     const node = isNode(pathOrNode)
       ? pathOrNode
       : (pathOrNode.walk(this.#root) as INode<V>)
+
+    if (this.isStale(node)) {
+      throw new StaleNodeError()
+    }
 
     const previous = this.#root.$unwrap()
     const result = mutate(this.#root, node.$path, mutation)

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -1,14 +1,14 @@
 // eslint-disable-next-line max-classes-per-file
-import Path from "./Path"
+import { NotAnArborNodeError, StaleNodeError } from "./errors"
 import isNode from "./isNode"
+import mutate, { Mutation, MutationMetadata } from "./mutate"
+import NodeArrayHandler from "./NodeArrayHandler"
 import NodeCache from "./NodeCache"
 import NodeHandler from "./NodeHandler"
-import NodeArrayHandler from "./NodeArrayHandler"
-import mutate, { Mutation, MutationMetadata } from "./mutate"
-import { NotAnArborNodeError, StaleNodeError } from "./errors"
-import Subscribers, { Subscriber, Unsubscribe } from "./Subscribers"
 import { notifyAffectedSubscribers } from "./notifyAffectedSubscribers"
-import { assignUUID, ArborUUID } from "./uuid"
+import Path from "./Path"
+import Subscribers, { Subscriber, Unsubscribe } from "./Subscribers"
+import { getUUID, setUUID } from "./uuid"
 
 /**
  * Describes a Node Hnalder constructor capable of determining which
@@ -258,7 +258,7 @@ export default class Arbor<T extends object = object> {
     const handler = new Handler(this, path, value, children, subscribers)
     const node = new Proxy<V>(value, handler) as INode<V>
 
-    assignUUID(value)
+    setUUID(value)
 
     return node
   }
@@ -337,7 +337,7 @@ export default class Arbor<T extends object = object> {
 
     const reloadedValue = reloadedNode.$unwrap()
     const value = node.$unwrap()
-    if (value[ArborUUID] === reloadedValue[ArborUUID]) return false
+    if (getUUID(value) === getUUID(reloadedValue)) return false
     if (global.DEBUG) {
       // eslint-disable-next-line no-console
       console.warn(`Stale node pointing to path ${node.$path.toString()}`)

--- a/packages/arbor-store/src/BaseNode.ts
+++ b/packages/arbor-store/src/BaseNode.ts
@@ -14,6 +14,7 @@ export default class BaseNode<T extends object> {
     return true
   }
 
+  // TODO: throw StaleNodeError when node is stale
   parent<K extends object>(): INode<K> {
     const node = this
     if (!isNode(node)) throw new NotAnArborNodeError()
@@ -27,6 +28,7 @@ export default class BaseNode<T extends object> {
     return node.$tree.getNodeAt(parentPath)
   }
 
+  // TODO: throw StaleNodeError when node is stale
   detach() {
     const node = this
     if (!isNode(node)) throw new NotAnArborNodeError()
@@ -68,6 +70,7 @@ export default class BaseNode<T extends object> {
     return this.$tree.getNodeAt(this.$path)
   }
 
+  // TODO: throw StaleNodeError when node is stale
   reload(): BaseNode<T> {
     if (!isNode(this)) throw new NotAnArborNodeError()
 
@@ -78,6 +81,7 @@ export default class BaseNode<T extends object> {
     return this.reload() != null
   }
 
+  // TODO: use Arbor#isStale instead
   isStale(): boolean {
     return this !== this.reload()
   }

--- a/packages/arbor-store/src/NodeArrayHandler.test.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.test.ts
@@ -194,6 +194,28 @@ describe("NodeArrayHandler", () => {
       })
     })
 
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" }
+        ],
+        users2: [
+          { name: "Bob" }
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      delete users1[0]
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     describe("mode = 'forgiven'", () => {
       it("propates mutation side-effects to the original node's underlying value", () => {
         const state = [
@@ -222,6 +244,28 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#splice", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" }
+        ],
+        users2: [
+          { name: "Bob" }
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.splice(0, 1)
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [
         { name: "User 1", address: { street: "Street 1" } },
@@ -368,6 +412,28 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#push", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" }
+        ],
+        users2: [
+          { name: "Bob" }
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.push({ name: "Carol" })
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [{ name: "User 1", address: { street: "Street 1" } }]
 
@@ -476,6 +542,29 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#reverse", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" }
+        ],
+        users2: [
+          { name: "Carol" },
+          { name: "Bob" }
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.reverse()
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [
         { name: "User 1", address: { street: "Street 1" } },
@@ -646,6 +735,28 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#pop", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" }
+        ],
+        users2: [
+          { name: "Bob" }
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.pop()
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [
         { name: "User 1", address: { street: "Street 1" } },
@@ -794,6 +905,28 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#shift", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" }
+        ],
+        users2: [
+          { name: "Bob" }
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.shift()
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [
         { name: "User 1", address: { street: "Street 1" } },
@@ -923,6 +1056,30 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#sort", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Carol" },
+          { name: "Alice" },
+        ],
+        users2: [
+          { name: "Carol" },
+          { name: "Bob" },
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.sort((a, b) => a.name.localeCompare(b.name))
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [
         { name: "User 2", address: { street: "Street 2" } },
@@ -1070,6 +1227,28 @@ describe("NodeArrayHandler", () => {
   })
 
   describe("#unshift", () => {
+    it("ignores mutations on stale array node", () => {
+      const store = new Arbor({
+        users1: [
+          { name: "Alice" },
+        ],
+        users2: [
+          { name: "Bob" },
+        ]
+      })
+
+      const users1 = store.state.users1
+      const users2 = store.state.users2
+
+      store.state.users1 = users2
+
+      expect(store.state.users1).toEqual(users2)
+
+      users1.unshift({ name: "Carol" })
+
+      expect(store.state.users1).toEqual(users2)
+    })
+
     it("generates a new state tree root node", () => {
       const state = [{ name: "User 3", address: { street: "Street 3" } }]
 

--- a/packages/arbor-store/src/NodeArrayHandler.test.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.test.ts
@@ -2,6 +2,7 @@ import Path from "./Path"
 import { unwrap, warmup } from "./test.helpers"
 import NodeArrayHandler from "./NodeArrayHandler"
 import Arbor, { INode, MutationMode } from "./Arbor"
+import { StaleNodeError } from "./errors"
 
 interface Address {
   street: string
@@ -211,7 +212,7 @@ describe("NodeArrayHandler", () => {
 
       expect(store.state.users1).toEqual(users2)
 
-      delete users1[0]
+      expect(() => { delete users1[0] }).toThrowError(StaleNodeError)
 
       expect(store.state.users1).toEqual(users2)
     })
@@ -260,9 +261,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.splice(0, 1)
-
+      expect(() => { users1.splice(0, 1) }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 
@@ -428,9 +427,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.push({ name: "Carol" })
-
+      expect(() => { users1.push({ name: "Carol" }) }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 
@@ -559,9 +556,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.reverse()
-
+      expect(() => { users1.reverse() }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 
@@ -751,9 +746,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.pop()
-
+      expect(() => { users1.pop() }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 
@@ -921,9 +914,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.shift()
-
+      expect(() => { users1.shift() }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 
@@ -1074,9 +1065,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.sort((a, b) => a.name.localeCompare(b.name))
-
+      expect(() => { users1.sort((a, b) => a.name.localeCompare(b.name)) }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 
@@ -1243,9 +1232,7 @@ describe("NodeArrayHandler", () => {
       store.state.users1 = users2
 
       expect(store.state.users1).toEqual(users2)
-
-      users1.unshift({ name: "Carol" })
-
+      expect(() => { users1.unshift({ name: "Carol" }) }).toThrowError(StaleNodeError)
       expect(store.state.users1).toEqual(users2)
     })
 

--- a/packages/arbor-store/src/NodeArrayHandler.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.ts
@@ -9,8 +9,6 @@ export default class NodeArrayHandler<
   }
 
   deleteProperty(_target: T[], prop: string): boolean {
-    if (this.$tree.isStale(this)) return true
-
     this.$tree.mutate(this, (node: T[]) => {
       node.splice(parseInt(prop, 10), 1)
 
@@ -26,8 +24,6 @@ export default class NodeArrayHandler<
   }
 
   push(...item: T[]): number {
-    if (this.$tree.isStale(this)) return 0
-
     let size: number
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -43,8 +39,6 @@ export default class NodeArrayHandler<
   }
 
   reverse() {
-    if (this.$tree.isStale(this)) return this
-
     this.$tree.mutate(this, (node: T[]) => {
       node.reverse()
 
@@ -60,8 +54,6 @@ export default class NodeArrayHandler<
   }
 
   pop(): T {
-    if (this.$tree.isStale(this)) return undefined
-
     let popped: T
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -80,8 +72,6 @@ export default class NodeArrayHandler<
   }
 
   shift(): T {
-    if (this.$tree.isStale(this)) return undefined
-
     let shifted: T
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -99,8 +89,6 @@ export default class NodeArrayHandler<
   }
 
   sort(compareFn: (a: T, b: T) => number) {
-    if (this.$tree.isStale(this)) return this
-
     this.$tree.mutate(this, (node: T[]) => {
       node.sort(compareFn)
 
@@ -116,8 +104,6 @@ export default class NodeArrayHandler<
   }
 
   splice(start: number, deleteCount: number, ...items: T[]): T[] {
-    if (this.$tree.isStale(this)) return []
-
     let deleted: T[] = []
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -137,8 +123,6 @@ export default class NodeArrayHandler<
   }
 
   unshift(...items: T[]): number {
-    if (this.$tree.isStale(this)) return 0
-
     let size: number
 
     this.$tree.mutate(this, (node: T[]) => {

--- a/packages/arbor-store/src/NodeArrayHandler.ts
+++ b/packages/arbor-store/src/NodeArrayHandler.ts
@@ -9,6 +9,8 @@ export default class NodeArrayHandler<
   }
 
   deleteProperty(_target: T[], prop: string): boolean {
+    if (this.$tree.isStale(this)) return true
+
     this.$tree.mutate(this, (node: T[]) => {
       node.splice(parseInt(prop, 10), 1)
 
@@ -24,6 +26,8 @@ export default class NodeArrayHandler<
   }
 
   push(...item: T[]): number {
+    if (this.$tree.isStale(this)) return 0
+
     let size: number
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -39,6 +43,8 @@ export default class NodeArrayHandler<
   }
 
   reverse() {
+    if (this.$tree.isStale(this)) return this
+
     this.$tree.mutate(this, (node: T[]) => {
       node.reverse()
 
@@ -54,6 +60,8 @@ export default class NodeArrayHandler<
   }
 
   pop(): T {
+    if (this.$tree.isStale(this)) return undefined
+
     let popped: T
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -72,6 +80,8 @@ export default class NodeArrayHandler<
   }
 
   shift(): T {
+    if (this.$tree.isStale(this)) return undefined
+
     let shifted: T
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -88,7 +98,9 @@ export default class NodeArrayHandler<
     return shifted
   }
 
-  sort(compareFn: (a: T, b: T) => number): T[] {
+  sort(compareFn: (a: T, b: T) => number) {
+    if (this.$tree.isStale(this)) return this
+
     this.$tree.mutate(this, (node: T[]) => {
       node.sort(compareFn)
 
@@ -104,6 +116,8 @@ export default class NodeArrayHandler<
   }
 
   splice(start: number, deleteCount: number, ...items: T[]): T[] {
+    if (this.$tree.isStale(this)) return []
+
     let deleted: T[] = []
 
     this.$tree.mutate(this, (node: T[]) => {
@@ -123,6 +137,8 @@ export default class NodeArrayHandler<
   }
 
   unshift(...items: T[]): number {
+    if (this.$tree.isStale(this)) return 0
+
     let size: number
 
     this.$tree.mutate(this, (node: T[]) => {

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -88,8 +88,6 @@ export default class NodeHandler<
   }
 
   set(target: T, prop: string, newValue: any, proxy: INode<T>): boolean {
-    if (this.$tree.isStale(this)) return true
-
     // Ignores the mutation if new value is the current value
     if (proxy[prop] === newValue || target[prop] === newValue) return true
 
@@ -98,6 +96,10 @@ export default class NodeHandler<
     // clone assigned values to force Arbor to recompute that new value's path, otherwise
     // different nodes pointing to the same value would have the same path, and paths must
     // always be unique within the state tree.
+    //
+    // TODO: revisit the clonning bit.
+    // This will likely prevent reference assignments from happening
+    // which may not be intuitive.
     const value = isProxiable(newValue) ? clone(newValue) : newValue
 
     this.$tree.mutate(proxy, (t: T) => {
@@ -113,8 +115,6 @@ export default class NodeHandler<
   }
 
   deleteProperty(target: T, prop: string): boolean {
-    if (this.$tree.isStale(this)) return true
-
     if (prop in target) {
       const childValue = Reflect.get(target, prop) as any
 

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -88,6 +88,8 @@ export default class NodeHandler<
   }
 
   set(target: T, prop: string, newValue: any, proxy: INode<T>): boolean {
+    if (this.$tree.isStale(this)) return true
+
     // Ignores the mutation if new value is the current value
     if (proxy[prop] === newValue || target[prop] === newValue) return true
 
@@ -111,6 +113,8 @@ export default class NodeHandler<
   }
 
   deleteProperty(target: T, prop: string): boolean {
+    if (this.$tree.isStale(this)) return true
+
     if (prop in target) {
       const childValue = Reflect.get(target, prop) as any
 

--- a/packages/arbor-store/src/clone.ts
+++ b/packages/arbor-store/src/clone.ts
@@ -2,7 +2,8 @@ import isNode from "./isNode"
 import isProxiable from "./isProxiable"
 import isClonable from "./isClonable"
 
-import type { AttributesOf } from "./Arbor"
+import { AttributesOf } from "./Arbor"
+import { ArborUUID, assignUUID } from "./uuid"
 
 export type Constructor<T extends object> = new (...args: any[]) => T
 
@@ -15,13 +16,17 @@ export default function clone<T extends object>(
   if (!isProxiable(target)) return value
 
   if (isClonable<T>(target)) {
-    return target.$clone()
+    const c = target.$clone()
+    assignUUID(c, target[ArborUUID])
+    return c
   }
 
   const Constructor = target?.constructor as Constructor<T>
 
-  return Object.assign(new Constructor(), {
+  const c = Object.assign(new Constructor(), {
     ...target,
     ...overrides,
   })
+  assignUUID(c, target[ArborUUID])
+  return c
 }

--- a/packages/arbor-store/src/clone.ts
+++ b/packages/arbor-store/src/clone.ts
@@ -3,30 +3,30 @@ import isProxiable from "./isProxiable"
 import isClonable from "./isClonable"
 
 import { AttributesOf } from "./Arbor"
-import { ArborUUID, assignUUID } from "./uuid"
+import { getUUID, setUUID } from "./uuid"
 
 export type Constructor<T extends object> = new (...args: any[]) => T
+
+function cloneFromConstructor<T extends object>(target: object, overrides: Partial<AttributesOf<T>>) {
+  const Constructor = target?.constructor as Constructor<T>
+  return Object.assign(new Constructor(), {
+    ...target,
+    ...overrides,
+  })
+}
 
 export default function clone<T extends object>(
   value: T,
   overrides: Partial<AttributesOf<T>> = {}
 ): T {
   const target = isNode(value) ? value.$unwrap() : value
+  const targetUUID = getUUID(target)
 
   if (!isProxiable(target)) return value
 
-  if (isClonable<T>(target)) {
-    const c = target.$clone()
-    assignUUID(c, target[ArborUUID])
-    return c
-  }
+  const cloned = isClonable<T>(target)
+    ? target.$clone()
+    : cloneFromConstructor<T>(target, overrides)
 
-  const Constructor = target?.constructor as Constructor<T>
-
-  const c = Object.assign(new Constructor(), {
-    ...target,
-    ...overrides,
-  })
-  assignUUID(c, target[ArborUUID])
-  return c
+  return setUUID(cloned, targetUUID)
 }

--- a/packages/arbor-store/src/errors.ts
+++ b/packages/arbor-store/src/errors.ts
@@ -14,3 +14,9 @@ export class NotAnArborNodeError extends ArborError {
     super("Object not bound to an Arbor store")
   }
 }
+
+export class StaleNodeError extends ArborError {
+  constructor() {
+    super("Mutation attempt on a stale node")
+  }
+}

--- a/packages/arbor-store/src/uuid.ts
+++ b/packages/arbor-store/src/uuid.ts
@@ -17,11 +17,7 @@ export function getUUID(value: object): UUID | undefined {
 
 export function setUUID<T extends object>(value: T, uuid = new UUID()) {
   if (!(ArborUUID in value)) {
-    Object.defineProperty(value, ArborUUID, {
-      value: uuid,
-      enumerable: false,
-      configurable: false,
-    })
+    Object.defineProperty(value, ArborUUID, { value: uuid })
   }
 
   return value

--- a/packages/arbor-store/src/uuid.ts
+++ b/packages/arbor-store/src/uuid.ts
@@ -9,12 +9,20 @@
  * by Arbor to avoid overriding state with stale values.
  */
 class UUID { }
-export const ArborUUID = Symbol.for("ArborUUID");
-export function assignUUID(value: object, uuid = new UUID()) {
+const ArborUUID = Symbol.for("ArborUUID")
+
+export function getUUID(value: object): UUID | undefined {
+  return value?.[ArborUUID]
+}
+
+export function setUUID<T extends object>(value: T, uuid = new UUID()) {
   if (!(ArborUUID in value)) {
     Object.defineProperty(value, ArborUUID, {
       value: uuid,
       enumerable: false,
-    });
+      configurable: false,
+    })
   }
+
+  return value
 }

--- a/packages/arbor-store/src/uuid.ts
+++ b/packages/arbor-store/src/uuid.ts
@@ -1,0 +1,20 @@
+/**
+ * Represents a unique identifier used to track values within Arbor's state tree.
+ *
+ * Every node's value gets "stamped" with an non enumerable UUID property that
+ * carries over to their new values upon every mutation. This allows Arbor to
+ * track values across different state snapshots, enabling to determine when
+ * a node is remove from the state tree or moves into a different path rendering
+ * them stale, at which point mutations on that node reference are simply ignored
+ * by Arbor to avoid overriding state with stale values.
+ */
+class UUID { }
+export const ArborUUID = Symbol.for("ArborUUID");
+export function assignUUID(value: object, uuid = new UUID()) {
+  if (!(ArborUUID in value)) {
+    Object.defineProperty(value, ArborUUID, {
+      value: uuid,
+      enumerable: false,
+    });
+  }
+}


### PR DESCRIPTION
Provide a mechanism for tracking node values across state tree snapshots.

One particular challenge within Arbor is to be able to determine when a reference to a node still belongs to the state tree or even if the node was not moved to a different path within the state tree.

This is important since there can be stale node references in code. Take the following example:

```ts
const store = new Arbor({
  user1: { name: "Alice" },
  user2: { name: "Bob" },
})

const alice = store.state.user1
const bob = store.state.user2

store.state.user1 = bob

// Prior to this change, the following mutation would actually
// set store.state.user1.name to "Alice Doe", even though
// "Alice" was replaced by "Bob" on the mutation above.
alice.name = "Alice Doe"
```
