### PR TITLE
Properly traverses mutation path when notifying map children nodes

### DIFF
--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -1025,6 +1025,19 @@ describe("Arbor", () => {
 
       expect(node).toBe(store.state.todos.get("123"))
     })
+
+    it("traverses children nodes successfully when notifying about mutations", () => {
+      const todosMap = new Map<string, { text: string }>()
+      todosMap.set("123", { text: "Walk the dogs" })
+      todosMap.set("abc", { text: "Clean the house" })
+
+      const store = new Arbor(todosMap)
+      const todo = store.state.get("abc")!
+
+      todo.text = "House cleaned"
+
+      expect(store.state.get("abc")!.text).toBe("House cleaned")
+    })
   })
 
   describe("Example: Repository of nodes", () => {

--- a/packages/arbor-store/src/notifyAffectedSubscribers.ts
+++ b/packages/arbor-store/src/notifyAffectedSubscribers.ts
@@ -8,7 +8,7 @@ export function notifyAffectedSubscribers<T extends object>(
   root.$subscribers.notify(event)
 
   event.mutationPath.props.reduce((parent: INode, prop: string) => {
-    const node = parent[prop] as INode
+    const node = parent.$traverse(prop) as INode
     node.$subscribers.notify(event)
     return node
   }, root)


### PR DESCRIPTION
As part of https://github.com/drborges/arbor/pull/85 I failed to update the mutation notification logic that was not leveraging the new `INode#$traverse` method in order to traverse the mutation path within the state tree.

This new method enables the usage of data structures that do not provide index accessor syntax to retrieve children values, in this case `Map` instances that require one to use `Map#get` in order to access items stored in the data structure.