### PR TITLE
Decorator system

### DIFF
--- a/packages/arbor-react/src/useArbor.test.ts
+++ b/packages/arbor-react/src/useArbor.test.ts
@@ -1,4 +1,4 @@
-import { Arbor, ArborNode, Path, Proxiable } from "@arborjs/store"
+import { Arbor, ArborNode, Path, proxiable } from "@arborjs/store"
 import { act, renderHook } from "@testing-library/react-hooks"
 
 import useArbor, { Watcher } from "./useArbor"
@@ -88,7 +88,7 @@ describe("useArbor", () => {
   })
 
   it("supports custom object types to represent the state", () => {
-    @Proxiable()
+    @proxiable
     class InputHandler {
       value = ""
       settings = {}

--- a/packages/arbor-react/src/watchNode.test.ts
+++ b/packages/arbor-react/src/watchNode.test.ts
@@ -1,4 +1,4 @@
-import { Arbor, Proxiable } from "@arborjs/store"
+import { Arbor, proxiable } from "@arborjs/store"
 import { act, renderHook } from "@testing-library/react-hooks"
 
 import useArbor from "./useArbor"
@@ -94,7 +94,7 @@ describe("watchNode", () => {
   })
 
   it("watches a BseNode value", () => {
-    @Proxiable()
+    @proxiable
     class User {
       name: string
       age: number

--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable max-classes-per-file */
-import Arbor, { ArborNode, proxiable } from "./Arbor"
+import Arbor, { ArborNode } from "./Arbor"
 import Path from "./Path"
+import { ArborProxiable, proxiable } from "./decorators"
 import {
   ArborError,
   DetachedNodeError,
@@ -9,7 +10,6 @@ import {
   ValueAlreadyBoundError,
 } from "./errors"
 
-import { ArborProxiable } from "./guards"
 import { detach, isDetached, merge, path, unwrap } from "./utilities"
 
 describe("Arbor", () => {

--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable max-classes-per-file */
-import Arbor, { ArborNode, Proxiable } from "./Arbor"
+import Arbor, { ArborNode, proxiable } from "./Arbor"
 import Path from "./Path"
 import {
   ArborError,
@@ -228,7 +228,7 @@ describe("Arbor", () => {
     })
 
     it("allows deleting nodes by detaching them from the state tree", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         text: string
 
@@ -480,7 +480,7 @@ describe("Arbor", () => {
     })
 
     it("marks a custom type as proxiable via decorator", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(public text: string, public status = "todo") {}
         complete() {
@@ -501,7 +501,7 @@ describe("Arbor", () => {
     })
 
     it("allows using class getters to select nodes within the state tree", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(
           readonly id: number,
@@ -510,7 +510,7 @@ describe("Arbor", () => {
         ) {}
       }
 
-      @Proxiable()
+      @proxiable
       class TodoList {
         todos: Todo[] = []
 
@@ -801,7 +801,7 @@ describe("Arbor", () => {
 
   describe("Example: Reactive Map API", () => {
     it("allows tracking nodes stored within Map instances", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(public text: string) {}
       }
@@ -885,7 +885,7 @@ describe("Arbor", () => {
     })
 
     it("allows deleting nodes stored within Map instances", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(public text: string) {}
       }
@@ -917,7 +917,7 @@ describe("Arbor", () => {
     })
 
     it("allows clearing a Map of nodes", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(public text: string) {}
       }
@@ -949,7 +949,7 @@ describe("Arbor", () => {
     })
 
     it("allows iterating over Map values", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(public text: string) {}
       }
@@ -971,7 +971,7 @@ describe("Arbor", () => {
     })
 
     it("allows iterating over Map entries", () => {
-      @Proxiable()
+      @proxiable
       class Todo {
         constructor(public text: string) {}
       }

--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable max-classes-per-file */
 import Arbor, { ArborNode } from "./Arbor"
 import Path from "./Path"
-import { ArborProxiable, proxiable } from "./decorators"
+import { ArborProxiable, detached, proxiable } from "./decorators"
 import {
   ArborError,
   DetachedNodeError,
@@ -111,6 +111,33 @@ describe("Arbor", () => {
       store.state.user2 = aliceNode
 
       expect(unwrap(store.state.user2)).toBe(alice)
+    })
+
+    it("allows marking node properties as detached to avoid updates", () => {
+      @proxiable
+      class Todo {
+        @detached count = 0
+
+        @detached
+        tracker = {
+          count: 0,
+        }
+
+        constructor(public text: string) {}
+      }
+
+      const store = new Arbor([
+        new Todo("Clean the house"),
+        new Todo("Walk the dogs"),
+      ])
+
+      const subscriber = jest.fn()
+      store.subscribe(subscriber)
+
+      store.state[0].count++
+      store.state[0].tracker.count++
+
+      expect(subscriber).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -6,29 +6,9 @@ import NodeMapHandler from "./NodeMapHandler"
 import Path from "./Path"
 import Subscribers, { Subscriber, Unsubscribe } from "./Subscribers"
 import { DetachedNodeError, NotAnArborNodeError } from "./errors"
-import { ArborProxiable, isNode } from "./guards"
+import { isNode } from "./guards"
 import mutate, { Mutation, MutationMetadata } from "./mutate"
 import { notifyAffectedSubscribers } from "./notifyAffectedSubscribers"
-
-/**
- * Decorates a class marking it as Arbor proxiable, allowing
- * Arbor to use it as Node type.
- *
- * @example
- *
- * ```ts
- * @proxiable
- * class Todo {
- *   text: string
- * }
- * ```
- */
-export function proxiable<T extends Function>(
-  target: T,
-  _context: unknown = null
-) {
-  target.prototype[ArborProxiable] = true
-}
 
 /**
  * Describes a Node Hnalder constructor capable of determining which

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -14,12 +14,20 @@ import { notifyAffectedSubscribers } from "./notifyAffectedSubscribers"
  * Decorates a class marking it as Arbor proxiable, allowing
  * Arbor to use it as Node type.
  *
- * @returns Arbor compatiby type.
+ * @example
+ *
+ * ```ts
+ * @proxiable
+ * class Todo {
+ *   text: string
+ * }
+ * ```
  */
-export function Proxiable() {
-  return <T extends Function>(target: T, _context: unknown = null) => {
-    target.prototype[ArborProxiable] = true
-  }
+export function proxiable<T extends Function>(
+  target: T,
+  _context: unknown = null
+) {
+  target.prototype[ArborProxiable] = true
 }
 
 /**

--- a/packages/arbor-store/src/Path.ts
+++ b/packages/arbor-store/src/Path.ts
@@ -96,7 +96,7 @@ export default class Path {
    */
   walkObj(obj: object): unknown {
     try {
-      return this.props.reduce((parent, part) => parent[part] as unknown, obj)
+      return this.props.reduce((parent, part) => parent[part], obj)
     } catch {
       return undefined
     }

--- a/packages/arbor-store/src/decorators.ts
+++ b/packages/arbor-store/src/decorators.ts
@@ -1,3 +1,4 @@
+export const ArborDetached = Symbol.for("ArborDetached")
 export const ArborProxiable = Symbol.for("ArborProxiable")
 
 /**
@@ -18,4 +19,31 @@ export function proxiable<T extends Function>(
   _context: unknown = null
 ) {
   target.prototype[ArborProxiable] = true
+}
+
+/**
+ * Detaches an object's property from the state tree.
+ *
+ * Mutation to detached properties will not trigger store updates.
+ *
+ * @param target the object owning the property.
+ * @param prop the property to detach from the state tree.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function detached(target: any, prop: any) {
+  target[ArborDetached] = target[ArborDetached] || {}
+  const detachedProps = target[ArborDetached]
+  detachedProps[prop] = true
+}
+
+/**
+ * Checks if a property belonging to a given object is detached from the state tree.
+ *
+ * @param target the object owning the property.
+ * @param prop the property to check.
+ * @returns true if the property is detached from the state tree.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isDetachedProperty(target: any, prop: string) {
+  return target?.[ArborDetached]?.[prop]
 }

--- a/packages/arbor-store/src/decorators.ts
+++ b/packages/arbor-store/src/decorators.ts
@@ -1,0 +1,21 @@
+export const ArborProxiable = Symbol.for("ArborProxiable")
+
+/**
+ * Decorates a class marking it as Arbor proxiable, allowing
+ * Arbor to use it as Node type.
+ *
+ * @example
+ *
+ * ```ts
+ * @proxiable
+ * class Todo {
+ *   text: string
+ * }
+ * ```
+ */
+export function proxiable<T extends Function>(
+  target: T,
+  _context: unknown = null
+) {
+  target.prototype[ArborProxiable] = true
+}

--- a/packages/arbor-store/src/guards.test.ts
+++ b/packages/arbor-store/src/guards.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable no-new-wrappers */
-import Arbor, { proxiable } from "./Arbor"
-import { ArborProxiable, isNode, isProxiable } from "./guards"
+import Arbor from "./Arbor"
+import { ArborProxiable, proxiable } from "./decorators"
+import { isNode, isProxiable } from "./guards"
 
 @proxiable
 class User {}

--- a/packages/arbor-store/src/guards.test.ts
+++ b/packages/arbor-store/src/guards.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-classes-per-file */
 /* eslint-disable no-new-wrappers */
-import Arbor, { Proxiable } from "./Arbor"
+import Arbor, { proxiable } from "./Arbor"
 import { ArborProxiable, isNode, isProxiable } from "./guards"
 
-@Proxiable()
+@proxiable
 class User {}
 class NotProxiable {}
 class Users extends Array {}
@@ -24,7 +24,7 @@ describe("isProxiable", () => {
     expect(isProxiable(new Users())).toBe(true)
   })
 
-  it("considers proxiable user-defined types annotated with the @Proxiable() decorator", () => {
+  it("considers proxiable user-defined types annotated with the @proxiable decorator", () => {
     expect(isProxiable(new User())).toBe(true)
   })
 

--- a/packages/arbor-store/src/guards.ts
+++ b/packages/arbor-store/src/guards.ts
@@ -1,4 +1,5 @@
 import Arbor, { ArborNode, INode } from "./Arbor"
+import { ArborProxiable } from "./decorators"
 
 export function isNode<T extends object>(value: unknown): value is INode<T> {
   const isNodeValue = value as INode<T>
@@ -10,8 +11,6 @@ export function isArborNode<T extends object>(
 ): value is ArborNode<T> {
   return isNode(value)
 }
-
-export const ArborProxiable = Symbol.for("ArborProxiable")
 
 export function isProxiable(value: unknown): value is object {
   if (value == null) return false

--- a/packages/arbor-store/src/index.ts
+++ b/packages/arbor-store/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Arbor, proxiable } from "./Arbor"
+export { default as Arbor } from "./Arbor"
 export type {
   ArborConfig,
   ArborNode,
@@ -13,6 +13,7 @@ export { default as NodeHandler } from "./NodeHandler"
 export { default as Path } from "./Path"
 export { default as Subscribers } from "./Subscribers"
 export type { MutationEvent, Subscriber, Unsubscribe } from "./Subscribers"
+export * from "./decorators"
 export * from "./errors"
 export * from "./guards"
 export type { Mutation } from "./mutate"

--- a/packages/arbor-store/src/index.ts
+++ b/packages/arbor-store/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Arbor, Proxiable } from "./Arbor"
+export { default as Arbor, proxiable } from "./Arbor"
 export type {
   ArborConfig,
   ArborNode,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
+    "experimentalDecorators": true,
     "lib": ["es2021", "dom", "dom.iterable"],
     "jsx": "react"
   },


### PR DESCRIPTION
Here it is proposed a simple yet powerful decorator system that users can rely on in order to control Arbor's behavior in a more declarative way.

```ts
@proxiable
class Todo {
  @detached count = 0

  @detached
  tracker = {
    count: 0,
  }

  constructor(public text: string) {}
}
```

The basic two decorators available currently are:

- `@proxiable`: Enables developers to bring their own custom types to represent state tree Nodes into Arbor. I'm considering renaming this to `@node` to make the decorators terminology more specific to state tree concepts;
- `@detached`: Allows keeping node properties detached from the state tree so that mutations to these properties won't trigger state tree updates. In a React context, for instance, one may use detached node properties to achieve similar behavior to `useRef`.

For cases where decorators cannot be used, there will be an alternative:

```ts
import { ArborProxiable, ArborDetached } from "@arborjs/store"

class Todo {
  count = 0

  tracker = {
    count: 0,
  }

  constructor(public text: string) {}

  [ArborProxiable] = true
  [ArborDetached] = {
    tracker: true,
    count: true
  }
}
```