### PR TITLE
Consolidated path traversing logic

### DIFF
--- a/packages/arbor-store/src/Path.test.ts
+++ b/packages/arbor-store/src/Path.test.ts
@@ -99,30 +99,6 @@ describe("Path", () => {
     })
   })
 
-  describe("#walkObj", () => {
-    it("traverses a given object until it reaches the value referenced by the path", () => {
-      const path = Path.parse("/data/users/1")
-      const obj = {
-        data: {
-          users: [{ name: "User 1" }, { name: "User 2" }],
-        },
-      }
-
-      expect(path.walkObj(obj)).toBe(obj.data.users[1])
-    })
-
-    it("returns undefined if path does not reference any nodes within the state tree", () => {
-      const path = Path.parse("/data/todos/1")
-      const obj = {
-        data: {
-          users: [{ name: "User 1" }, { name: "User 2" }],
-        },
-      }
-
-      expect(path.walkObj(obj)).toBeUndefined()
-    })
-  })
-
   describe("#targets", () => {
     it("checks if a path targets another given path", () => {
       expect(Path.root.targets(Path.root)).toBe(true)

--- a/packages/arbor-store/src/Path.ts
+++ b/packages/arbor-store/src/Path.ts
@@ -80,10 +80,10 @@ export default class Path {
    * intersected by the path.
    * @returns the node referenced by the path.
    */
-  walk(
-    node: ArborNode<object>,
-    cb?: (child: ArborNode<object>, parent: ArborNode<object>) => void
-  ): ArborNode<object> {
+  walk<T extends object>(
+    node: object,
+    cb?: (child: object, parent: object) => void
+  ): T {
     try {
       return this.props.reduce((parent, part) => {
         const child = isNode(parent) ? parent.$traverse(part) : parent[part]

--- a/packages/arbor-store/src/Path.ts
+++ b/packages/arbor-store/src/Path.ts
@@ -1,5 +1,5 @@
 import { ArborNode } from "./Arbor"
-import { InvalidArgumentError, NotAnArborNodeError } from "./errors"
+import { InvalidArgumentError } from "./errors"
 import { isNode } from "./guards"
 
 /**
@@ -76,27 +76,20 @@ export default class Path {
    * Traverses a given node until reaching the node represented by the path.
    *
    * @param node an Arbor node to traverse.
+   * @param cb an optional callback that allows one to process intermediary nodes
+   * intersected by the path.
    * @returns the node referenced by the path.
    */
-  walk(node: ArborNode<object>): ArborNode<object> {
+  walk(
+    node: ArborNode<object>,
+    cb?: (child: ArborNode<object>, parent: ArborNode<object>) => void
+  ): ArborNode<object> {
     try {
-      if (!isNode(node)) throw new NotAnArborNodeError()
-
-      return this.props.reduce((parent, part) => parent.$traverse(part), node)
-    } catch {
-      return undefined
-    }
-  }
-
-  /**
-   * Traverses a given object until reaching the value represented by the path.
-   *
-   * @param obj an object to traverse.
-   * @returns the value referenced by the path.
-   */
-  walkObj(obj: object): unknown {
-    try {
-      return this.props.reduce((parent, part) => parent[part], obj)
+      return this.props.reduce((parent, part) => {
+        const child = isNode(parent) ? parent.$traverse(part) : parent[part]
+        if (cb) cb(child, parent)
+        return child
+      }, node)
     } catch {
       return undefined
     }

--- a/packages/arbor-store/src/mutate.ts
+++ b/packages/arbor-store/src/mutate.ts
@@ -28,14 +28,14 @@ export default function mutate<T extends object, K extends object>(
   try {
     const root = node.$clone()
 
-    const targetNode = path.walk(root, (child: INode, parent: INode) => {
+    const targetNode = path.walk<INode>(root, (child: INode, parent: INode) => {
       const childCopy = child.$clone()
       const childValue = childCopy.$unwrap()
 
       parent.$children.set(childValue, childCopy)
 
       return childCopy
-    }) as INode
+    })
 
     const metadata = mutation(targetNode.$unwrap() as unknown as K)
 

--- a/packages/arbor-store/src/mutate.ts
+++ b/packages/arbor-store/src/mutate.ts
@@ -28,15 +28,14 @@ export default function mutate<T extends object, K extends object>(
   try {
     const root = node.$clone()
 
-    const targetNode = path.props.reduce<INode<T>>((parent, prop) => {
-      const childNode = parent.$traverse(prop)
-      const childNodeCopy = childNode.$clone()
-      const childNodeValue = childNodeCopy.$unwrap()
+    const targetNode = path.walk(root, (child: INode, parent: INode) => {
+      const childCopy = child.$clone()
+      const childValue = childCopy.$unwrap()
 
-      parent.$children.set(childNodeValue, childNodeCopy)
+      parent.$children.set(childValue, childCopy)
 
-      return childNodeCopy
-    }, root)
+      return childCopy
+    }) as INode
 
     const metadata = mutation(targetNode.$unwrap() as unknown as K)
 

--- a/packages/arbor-store/src/notifyAffectedSubscribers.ts
+++ b/packages/arbor-store/src/notifyAffectedSubscribers.ts
@@ -7,9 +7,7 @@ export function notifyAffectedSubscribers<T extends object>(
   const root = event.store.state as INode
   root.$subscribers.notify(event)
 
-  event.mutationPath.props.reduce((parent: INode, prop: string) => {
-    const node = parent.$traverse(prop) as INode
-    node.$subscribers.notify(event)
-    return node
-  }, root)
+  event.mutationPath.walk(root, (child: INode) => {
+    child.$subscribers.notify(event)
+  })
 }


### PR DESCRIPTION
Extends `Path#walk` allowing callers to process intermediary nodes intersected by the path, ultimately consolidating the traversing algorithm used to perform mutations, notify subscribers, and retrieve nodes referenced by a Path.