### PR TITLE
Provide a better mechanism to extend Arbor's proxying behavior.

### DIFF
--- a/examples/react-todo/store/useTodos.ts
+++ b/examples/react-todo/store/useTodos.ts
@@ -73,6 +73,13 @@ export class Repository<T extends Record> extends Map<string, T> {
   map<K>(transform: (record: T) => K) {
     return Array.from(this.values()).map(transform)
   }
+
+  toJSON() {
+    return Array.from(this.entries()).reduce((obj, entry) => {
+      obj[entry[0]] = entry[1]
+      return obj
+    }, {})
+  }
 }
 
 export const store = new Arbor(new Repository<Todo>())

--- a/packages/arbor-plugins/src/LocalStorage.ts
+++ b/packages/arbor-plugins/src/LocalStorage.ts
@@ -74,10 +74,7 @@ export default class LocalStorage<T extends object> extends Storage<T> {
     return new Promise((resolve, reject) => {
       try {
         const serialize = this.config.serialize || JSON.stringify
-        window.localStorage.setItem(
-          this.config.key,
-          serialize(event.state.current)
-        )
+        window.localStorage.setItem(this.config.key, serialize(event.state))
         resolve()
       } catch (e) {
         reject(e)

--- a/packages/arbor-plugins/src/Logger.ts
+++ b/packages/arbor-plugins/src/Logger.ts
@@ -4,7 +4,10 @@ export class Logger<T extends object> implements Plugin<T> {
   constructor(readonly tag: string) {}
 
   async configure(store: Arbor<T>) {
+    let previousState = JSON.stringify(store.state)
+
     return store.subscribe((event) => {
+      const currentState = JSON.stringify(event.state)
       const operation = event.metadata?.operation?.toUpperCase()
       const path = event.mutationPath.toString()
       const props = event.metadata.props
@@ -20,14 +23,16 @@ export class Logger<T extends object> implements Plugin<T> {
       console.info(
         "  %ccurrent: %O",
         "color: lightgreen;",
-        JSON.parse(JSON.stringify(event.state.current))
+        JSON.parse(currentState)
       )
       console.info(
         "  %cprevious: %O",
         "color: #ff4040",
-        JSON.parse(JSON.stringify(event.state.previous))
+        JSON.parse(previousState)
       )
       console.info("")
+
+      previousState = currentState
     })
   }
 }

--- a/packages/arbor-store/src/Arbor.test.ts
+++ b/packages/arbor-store/src/Arbor.test.ts
@@ -52,15 +52,13 @@ describe("Arbor", () => {
 
       expect(counter.count).toBe(1)
       expect(store.state.count).toBe(1)
-      expect(subscriber.mock.calls[0][0].state.previous.count).toBe(0)
-      expect(subscriber.mock.calls[0][0].state.current.count).toBe(1)
+      expect(subscriber.mock.calls[0][0].state.count).toBe(1)
 
       counter.count++
 
       expect(counter.count).toBe(2)
       expect(store.state.count).toBe(2)
-      expect(subscriber.mock.calls[1][0].state.previous.count).toBe(1)
-      expect(subscriber.mock.calls[1][0].state.current.count).toBe(2)
+      expect(subscriber.mock.calls[1][0].state.count).toBe(2)
     })
 
     it("keeps stale node references in sync with the current state tree", () => {
@@ -244,13 +242,8 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls.length).toBe(1)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("delete")
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["2"])
-      expect(subscriber.mock.calls[0][0].state.current).toEqual({
+      expect(subscriber.mock.calls[0][0].state).toEqual({
         "1": { text: "Clean the house" },
-      })
-
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual({
-        "1": { text: "Clean the house" },
-        "2": { text: "Walk the dogs" },
       })
     })
 
@@ -282,13 +275,8 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls.length).toBe(1)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("delete")
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["2"])
-      expect(subscriber.mock.calls[0][0].state.current).toEqual({
+      expect(subscriber.mock.calls[0][0].state).toEqual({
         "1": { text: "Clean the house" },
-      })
-
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual({
-        "1": { text: "Clean the house" },
-        "2": { text: "Walk the dogs" },
       })
     })
   })
@@ -326,8 +314,7 @@ describe("Arbor", () => {
           expect(event.mutationPath.toString()).toEqual("/")
           expect(event.metadata.props).toEqual(["count"])
           expect(event.metadata.operation).toEqual("set")
-          expect(event.state.previous).toEqual({ count: 0 })
-          expect(event.state.current).toEqual({ count: -1 })
+          expect(event.state).toEqual({ count: -1 })
           resolve(null)
         })
 
@@ -381,12 +368,7 @@ describe("Arbor", () => {
           expect(event.mutationPath.toString()).toEqual("/0")
           expect(event.metadata.props).toEqual(["status"])
           expect(event.metadata.operation).toEqual("set")
-          expect(event.state.previous).toEqual([
-            { text: "Do the dishes", status: "todo" },
-            { text: "Clean the house", status: "doing" },
-          ])
-
-          expect(event.state.current).toEqual([
+          expect(event.state).toEqual([
             { text: "Do the dishes", status: "doing" },
             { text: "Clean the house", status: "doing" },
           ])
@@ -659,10 +641,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["1"])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("push")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-      ])
+      expect(subscriber.mock.calls[0][0].state).toBe(store.state)
 
       expect(store.state).toEqual([
         { text: "Do the dishes", status: "todo" },
@@ -685,13 +664,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["0", "1"])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("splice")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-        { text: "Walk the dogs", status: "todo" },
-        { text: "Clean the house", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(store.state).toEqual([{ text: "Clean the house", status: "todo" }])
     })
 
@@ -710,13 +683,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["0"])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("delete")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-        { text: "Walk the dogs", status: "todo" },
-        { text: "Clean the house", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(store.state).toEqual([
         { text: "Walk the dogs", status: "todo" },
         { text: "Clean the house", status: "todo" },
@@ -738,13 +705,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["0"])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("shift")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-        { text: "Walk the dogs", status: "todo" },
-        { text: "Clean the house", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(shiftedTodo).toEqual({ text: "Do the dishes", status: "todo" })
       expect(store.state).toEqual([
         { text: "Walk the dogs", status: "todo" },
@@ -767,13 +728,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual(["2"])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("pop")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-        { text: "Walk the dogs", status: "todo" },
-        { text: "Clean the house", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(poppedTodo).toEqual({ text: "Clean the house", status: "todo" })
       expect(store.state).toEqual([
         { text: "Do the dishes", status: "todo" },
@@ -798,12 +753,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual([])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("unshift")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-        { text: "Walk the dogs", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(length).toEqual(3)
       expect(store.state).toEqual([
         { text: "Clean the house", status: "todo" },
@@ -826,12 +776,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual([])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("reverse")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Do the dishes", status: "todo" },
-        { text: "Walk the dogs", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(reversed).toBe(store.state)
       expect(store.state).toEqual([
         { text: "Walk the dogs", status: "todo" },
@@ -854,13 +799,7 @@ describe("Arbor", () => {
       expect(subscriber.mock.calls[0][0].metadata.props).toEqual([])
       expect(subscriber.mock.calls[0][0].mutationPath).toEqual(Path.root)
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("sort")
-      expect(subscriber.mock.calls[0][0].state.current).toEqual(store.state)
-      expect(subscriber.mock.calls[0][0].state.previous).toEqual([
-        { text: "Walk the dogs", status: "todo" },
-        { text: "Clean the house", status: "todo" },
-        { text: "Do the dishes", status: "todo" },
-      ])
-
+      expect(subscriber.mock.calls[0][0].state).toEqual(store.state)
       expect(sorted).toBe(store.state)
       expect(store.state).toEqual([
         { text: "Clean the house", status: "todo" },
@@ -895,9 +834,7 @@ describe("Arbor", () => {
         Path.parse("/todos")
       )
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("set")
-      expect(subscriber.mock.calls[0][0].state.current).toBe(
-        unwrap(store.state)
-      )
+      expect(subscriber.mock.calls[0][0].state).toBe(store.state)
       expect(store.state.todos.get("123")).not.toBe(todosMap.get("123"))
       expect(store.state.todos.get("123")).toEqual(new Todo("Walk the dogs"))
       expect(store.state.todos.get("abc")).not.toBe(todosMap.get("abc"))
@@ -980,9 +917,7 @@ describe("Arbor", () => {
         Path.parse("/todos")
       )
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("delete")
-      expect(subscriber.mock.calls[0][0].state.current).toBe(
-        unwrap(store.state)
-      )
+      expect(subscriber.mock.calls[0][0].state).toBe(store.state)
       expect(store.state.todos.get("123")).toEqual(new Todo("Walk the dogs"))
       expect(store.state.todos.get("abc")).toBeUndefined()
     })
@@ -1012,9 +947,7 @@ describe("Arbor", () => {
         Path.parse("/todos")
       )
       expect(subscriber.mock.calls[0][0].metadata.operation).toEqual("clear")
-      expect(subscriber.mock.calls[0][0].state.current).toBe(
-        unwrap(store.state)
-      )
+      expect(subscriber.mock.calls[0][0].state).toBe(store.state)
       expect(store.state.todos.get("123")).toBeUndefined()
       expect(store.state.todos.get("abc")).toBeUndefined()
     })

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -7,7 +7,7 @@ import Path from "./Path"
 import Subscribers, { Subscriber, Unsubscribe } from "./Subscribers"
 import { DetachedNodeError, NotAnArborNodeError } from "./errors"
 import { isNode } from "./guards"
-import mutate, { Mutation, MutationMetadata } from "./mutate"
+import mutate, { Mutation } from "./mutate"
 import { notifyAffectedSubscribers } from "./notifyAffectedSubscribers"
 import { isDetached } from "./utilities"
 
@@ -262,7 +262,7 @@ export default class Arbor<T extends object = object> {
           return JSON.parse(previousState) as T
         },
       },
-      metadata: result.metadata as MutationMetadata,
+      metadata: result.metadata ? result.metadata : null,
       mutationPath: node.$path,
     })
   }

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -164,12 +164,35 @@ export default class Arbor<T extends object = object> {
   #root: INode<T>
 
   /**
+   * List of node handlers used to extend Arbor's default proxying mechanism.
+   *
+   * The best way to extend Arbor is to subclass it with your list of node handlers:
+   *
+   * @example
+   *
+   * ```ts
+   * class TodoListNodeHandler extends NodeHandler<Map<unknown, TodoList>> {
+   *  static accepts(value: unknown) {
+   *    return value instanceof TodoList
+   *  }
+   *
+   *  // Omitted implementation details
+   * }
+   *
+   * class MyArbor extends Arbor<TodoList> {
+   *   extensions = [TodoListNodeHandler]
+   * }
+   * ```
+   */
+  protected readonly extensions: Handler[] = []
+
+  /**
    * Create a new Arbor instance.
    *
    * @param initialState the initial state tree value
    */
-  constructor(initialState: T, { handlers = [] }: ArborConfig = {}) {
-    this.#handlers = [...handlers, ...defaultNodeHandlers]
+  constructor(initialState: T) {
+    this.#handlers = [...this.extensions, ...defaultNodeHandlers]
     this.setState(initialState)
   }
 

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line max-classes-per-file
-import NodeArrayHandler from "./NodeArrayHandler"
+import ArrayNodeHandler from "./ArrayNodeHandler"
+import MapNodeHandler from "./MapNodeHandler"
 import NodeCache from "./NodeCache"
 import NodeHandler from "./NodeHandler"
-import NodeMapHandler from "./NodeMapHandler"
 import Path from "./Path"
 import Subscribers, { Subscriber, Unsubscribe } from "./Subscribers"
 import { DetachedNodeError, NotAnArborNodeError } from "./errors"
@@ -128,7 +128,7 @@ export type AttributesOf<T extends object> = { [P in keyof T]: T[P] }
  * within the state tree as well as hook into write operations so that subscribers can
  * be notified accordingly and the next state tree generated via structural sharing.
  */
-const defaultNodeHandlers = [NodeArrayHandler, NodeMapHandler, NodeHandler]
+const defaultNodeHandlers = [ArrayNodeHandler, MapNodeHandler, NodeHandler]
 
 /**
  * Implements the Arbor state tree abstraction

--- a/packages/arbor-store/src/Arbor.ts
+++ b/packages/arbor-store/src/Arbor.ts
@@ -203,17 +203,6 @@ export default class Arbor<T extends object = object> {
    *
    * @example
    *
-   * Mutating a node referenced by a path:
-   *
-   * ```ts
-   * const store = new Arbor({ users: [] })
-   * store.mutate(Path.parse("/users"), node => node.push({ name: "John Doe" }))
-   * store.state
-   * => { users: [{ name: "John Doe" }]}
-   * ```
-   *
-   * Or using a node reference:
-   *
    * ```ts
    * const store = new Arbor({ users: [] })
    * store.mutate(store.state.users, node => node.push({ name: "John Doe" }))
@@ -221,21 +210,12 @@ export default class Arbor<T extends object = object> {
    * => { users: [{ name: "John Doe" }]}
    * ```
    *
-   * @param pathOrNode the path or the node within the state tree to be mutated.
-   * @param mutation a function responsible for mutating the target node at the given path.
+   * @param node the node within the state tree to be mutated.
+   * @param mutation a function that performs the mutation to the node.
    */
   mutate<V extends object>(node: ArborNode<V>, mutation: Mutation<V>): void
-  mutate<V extends object>(path: Path, mutation: Mutation<V>): void
   mutate<V extends object>(handler: NodeHandler<V>, mutation: Mutation<V>): void
-  mutate<V extends object>(
-    pathOrNode: ArborNode<V> | Path,
-    mutation: Mutation<V>
-  ): void {
-    const node =
-      pathOrNode instanceof Path
-        ? pathOrNode.walk(this.#root)
-        : (pathOrNode as INode<V>)
-
+  mutate<V extends object>(node: unknown, mutation: Mutation<V>): void {
     if (!isNode(node)) throw new NotAnArborNodeError()
 
     // Nodes that are no longer in the state tree or were moved into a different
@@ -249,6 +229,9 @@ export default class Arbor<T extends object = object> {
     // conditionally track snapshots of previous state trees since
     // most use-cases do not require such tracking, thus, this
     // serialization could be turned off by default.
+    // I'm considering removing the concept of a previous state from
+    // Arbor's core implementation in favor of having this functionality
+    // in a Plugin.
     const previousState = JSON.stringify(this.#root.$unwrap())
     const result = mutate(this.#root, node.$path, mutation)
 

--- a/packages/arbor-store/src/ArrayNodeHandler.ts
+++ b/packages/arbor-store/src/ArrayNodeHandler.ts
@@ -1,6 +1,6 @@
 import NodeHandler from "./NodeHandler"
 
-export default class NodeArrayHandler<
+export default class ArrayNodeHandler<
   T extends object = object
 > extends NodeHandler<T[]> {
   static accepts(value: unknown) {

--- a/packages/arbor-store/src/MapNodeHandler.ts
+++ b/packages/arbor-store/src/MapNodeHandler.ts
@@ -3,7 +3,7 @@ import NodeHandler from "./NodeHandler"
 import { NotAnArborNodeError, ValueAlreadyBoundError } from "./errors"
 import { isNode, isProxiable } from "./guards"
 
-export default class NodeMapHandler<
+export default class MapNodeHandler<
   T extends object = object
 > extends NodeHandler<Map<unknown, T>> {
   static accepts(value: unknown) {

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -78,6 +78,12 @@ export default class NodeHandler<T extends object = object>
     )
   }
 
+  $getOrCreateChildNode<V extends object>(prop: string, value: V): INode<V> {
+    return this.$children.has(value)
+      ? this.$children.get(value)
+      : this.$createChildNode(prop, value)
+  }
+
   get(target: T, prop: string, proxy: INode<T>) {
     // Access $unwrap, $clone, $children, etc...
     const handlerApiAccess = Reflect.get(this, prop, proxy)
@@ -118,9 +124,7 @@ export default class NodeHandler<T extends object = object>
       return childValue
     }
 
-    return this.$children.has(childValue)
-      ? this.$children.get(childValue)
-      : this.$createChildNode(prop, childValue)
+    return this.$getOrCreateChildNode(prop, childValue)
   }
 
   set(target: T, prop: string, newValue: unknown, proxy: INode<T>): boolean {
@@ -174,10 +178,7 @@ export default class NodeHandler<T extends object = object>
     return true
   }
 
-  protected $createChildNode<V extends object>(
-    prop: string,
-    value: V
-  ): INode<V> {
+  private $createChildNode<V extends object>(prop: string, value: V): INode<V> {
     const childPath = this.$path.child(prop)
     const childNode = this.$tree.createNode(childPath, value)
     return this.$children.set(value, childNode)

--- a/packages/arbor-store/src/NodeHandler.ts
+++ b/packages/arbor-store/src/NodeHandler.ts
@@ -9,6 +9,9 @@ import { isGetter } from "./utilities"
 
 const PROXY_HANDLER_API = ["apply", "get", "set", "deleteProperty"]
 
+/**
+ * Default node handler implementation.
+ */
 export default class NodeHandler<T extends object = object>
   implements ProxyHandler<T>
 {
@@ -28,16 +31,40 @@ export default class NodeHandler<T extends object = object>
     readonly $subscribers = new Subscribers()
   ) {}
 
+  /**
+   * Checks if this node handler implementation can handle a given value belonging to
+   * the state tree.
+   *
+   * Since this implementation is the default node handler, it will always return true
+   * no matter the value passed in.
+   *
+   * @param _value node value to check. Ignored by this implementation.
+   * @returns always true.
+   */
   static accepts(_value: unknown) {
     return true
   }
 
+  /**
+   * Method used by Arbor in order to traverse a Node and access its children.
+   *
+   * By default Arbor assumes that the state tree is composed by either plain objects
+   * or Arrays, thus, the default traversing logic is via prop indexing, e.g. node[prop].
+   *
+   * @param key the key/prop used to index the child node.
+   * @returns the child node.
+   */
   $traverse(key: unknown) {
     if (!isNode<T>(this)) throw new NotAnArborNodeError()
 
     return this[key as string] as INode
   }
 
+  /**
+   * Unwraps the node returning its underlying value.
+   *
+   * @returns the unwrapped node value.
+   */
   $unwrap(): T {
     return this.$value
   }

--- a/packages/arbor-store/src/NodeMapHandler.ts
+++ b/packages/arbor-store/src/NodeMapHandler.ts
@@ -53,11 +53,7 @@ export default class NodeMapHandler<
           return value
         }
 
-        const node = this.$children.has(value)
-          ? this.$children.get(value)
-          : this.$createChildNode(key, value)
-
-        return node
+        return this.$getOrCreateChildNode(key, value)
       }
     }
 

--- a/packages/arbor-store/src/Subscribers.ts
+++ b/packages/arbor-store/src/Subscribers.ts
@@ -1,4 +1,4 @@
-import Arbor from "./Arbor"
+import { ArborNode } from "./Arbor"
 import { MutationMetadata } from "./mutate"
 import Path from "./Path"
 
@@ -11,12 +11,7 @@ export type Unsubscribe = () => void
  * Describes a mutation event passed to subscribers
  */
 export type MutationEvent<T extends object> = {
-  // TODO: consider not exposing reactive state to plugins.
-  // If plugins wish to trigger mutations, perhaps it's a
-  // better idea to be explicit, and retrieve the node to
-  // mutate from the state tree.
-  store: Arbor<T>
-  state: { current?: T; previous?: T }
+  state: ArborNode<T>
   mutationPath: Path
   metadata: MutationMetadata
 }

--- a/packages/arbor-store/src/index.ts
+++ b/packages/arbor-store/src/index.ts
@@ -7,7 +7,7 @@ export type {
   INode,
   Plugin,
 } from "./Arbor"
-export { default as NodeArrayHandler } from "./NodeArrayHandler"
+export { default as ArrayNodeHandler } from "./ArrayNodeHandler"
 export { default as NodeCache } from "./NodeCache"
 export { default as NodeHandler } from "./NodeHandler"
 export { default as Path } from "./Path"

--- a/packages/arbor-store/src/notifyAffectedSubscribers.ts
+++ b/packages/arbor-store/src/notifyAffectedSubscribers.ts
@@ -4,7 +4,7 @@ import { MutationEvent } from "./Subscribers"
 export function notifyAffectedSubscribers<T extends object>(
   event: MutationEvent<T>
 ) {
-  const root = event.store.state as INode
+  const root = event.state as INode
   root.$subscribers.notify(event)
 
   event.mutationPath.walk(root, (child: INode) => {

--- a/packages/arbor-store/src/utilities.ts
+++ b/packages/arbor-store/src/utilities.ts
@@ -52,7 +52,7 @@ export function merge<T extends object>(
     throw new DetachedNodeError()
   }
 
-  node.$tree.mutate(node.$path, (value) => {
+  node.$tree.mutate(node as ArborNode<T>, (value) => {
     Object.assign(value, data)
     return {
       operation: "merge",


### PR DESCRIPTION
Arbor relies on the [Proxy API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to implement its reactive state tree data structure. Each node in the state tree is represented by a specific `NodeHandler` implementation depending on its data type, by default Arbor ships with a couple of `NodeHandler` implementations:

- `MapNodeHandler`: Implements the reactive proxying behavior for `Map` data types;
- `ArrayNodeHandler`: Implements the reactive proxying behavior for `Array` data types;
- `NodeHandler`: Implements the reactive proxying behavior for any literal object, or custom types [marked as proxiable](https://github.com/drborges/arbor/pull/94);

These primary node handlers are sufficient for most use cases, however, one can extend Arbor's reactivity system with their own Node Handler implementation. To do that one needs to:

1. Implement the new node handler class by extending from the basic `NodeHandler` class. Note that node handlers are basically [Proxy handler objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy) with a few extra APIs;
2. Create a new Arbor implementation with the new node handler configured as an extension.

Example:

```ts
// Application domain type 
class TodoList {}

class TodoListNodeHandler extends NodeHandler<TodoList> {
  // 1. Define any of the proxy handler traps that you may need (see Proxy docs for more details);
  // 2. You may override any of the NodeHandler methods to change the default behavior.

  static accepts(value: unknown) {
    return value instanceof TodoList
  }
}

class TodoListStore extends Arbor<TodoList> {
  extensions = [TodoListNodeHandler]
}

const store = new TodoListStore(new TodoList())
```