### PR TITLE
Introduces versioned schema to invalidate staled data on clients

### DIFF
--- a/packages/arbor-plugins/README.md
+++ b/packages/arbor-plugins/README.md
@@ -81,6 +81,10 @@ store.use(
 
 Using `@arborjs/json` to handle serialization/deserialization means that your application state will be serialized and save into local storage with type information preserved so when deserialized, what you get back are instances of the types composing the state, rather than raw literal objects and arrays.
 
+Sometimes, when there are changes in the data schema, the persisted data on the clients can't be deserialized anymore. To avoid parsing exceptions, you can use the `schemaVersion` config; when it's different from the schema persisted, it will silently not load anything from LocalStorage.
+
+```ts
+
 ## Custom Plugins
 
 > [!WARNING]

--- a/packages/arbor-plugins/README.md
+++ b/packages/arbor-plugins/README.md
@@ -81,9 +81,7 @@ store.use(
 
 Using `@arborjs/json` to handle serialization/deserialization means that your application state will be serialized and save into local storage with type information preserved so when deserialized, what you get back are instances of the types composing the state, rather than raw literal objects and arrays.
 
-Sometimes, when there are changes in the data schema, the persisted data on the clients can't be deserialized anymore. To avoid parsing exceptions, you can use the `schemaVersion` config; when it's different from the schema persisted, it will silently not load anything from LocalStorage.
-
-```ts
+Sometimes, when the data schema changes, the persisted data on the clients can't be deserialized anymore. To avoid parsing exceptions, you can use the `schemaVersion` config; when it's different from the schema persisted, it will silently not load anything from LocalStorage.
 
 ## Custom Plugins
 


### PR DESCRIPTION
Sometimes, the changes in the data schema make it impossible for the plugin to parse the persisted data. This PR creates a mechanism to check if the data is still valid and silently not load anything if it's not.