### PR TITLE
Arbor store - Proxying improvements

### DIFF
--- a/packages/arbor-react/src/useArbor.ts
+++ b/packages/arbor-react/src/useArbor.ts
@@ -1,6 +1,7 @@
 import {
   Arbor,
   ArborNode,
+  isDetached,
   isNode,
   isProxiable,
   ScopedStore,
@@ -76,7 +77,9 @@ function useArborDeprecated<T extends object>(store: Store<T>): ArborNode<T> {
     }
 
     return store.subscribe(() => {
-      setState(store.state)
+      if (!isDetached(store.state)) {
+        setState(store.state)
+      }
     })
   }, [state, store])
 

--- a/packages/arbor-react/tests/useArbor.test.ts
+++ b/packages/arbor-react/tests/useArbor.test.ts
@@ -67,14 +67,14 @@ describe("useArbor", () => {
 
     const { result, unmount } = renderHook(() => useArbor(store))
 
-    const initialSstate = result.current
+    const initialState = result.current
 
     act(() => {
       result.current.count++
     })
 
     const nextState = result.current
-    expect(initialSstate).not.toBe(nextState)
+    expect(initialState).not.toBe(nextState)
 
     unmount()
 

--- a/packages/arbor-store/src/utilities.ts
+++ b/packages/arbor-store/src/utilities.ts
@@ -95,7 +95,15 @@ export function isDetached<T extends object>(node: T): boolean {
   // but an ancestor has been detached.'
   if (!isNode(node)) return true
 
-  return !node.$tree.getLinkFor(node) && !node.$tree.getNodeFor<Node>(node)
+  const path = node.$tree.getPathFor(node)
+
+  if (!path) {
+    return true
+  }
+
+  return path.seeds.some(
+    (seed) => !node.$tree.getLinkFor(seed) && !node.$tree.getNodeFor<Node>(seed)
+  )
 }
 
 /**

--- a/packages/arbor-store/tests/utilities/isDetached.test.ts
+++ b/packages/arbor-store/tests/utilities/isDetached.test.ts
@@ -25,4 +25,18 @@ describe("isDetached", () => {
 
     expect(isDetached(node)).toBe(true)
   })
+
+  it("returns true if the node belongs to a detached path", () => {
+    const store = new Arbor({
+      todos: [
+        { id: 1, text: "Do the dishes", author: { name: "Alice" } },
+        { id: 2, text: "Walk the dogs", author: { name: "Bob" } },
+      ],
+    })
+
+    const alice = store.state.todos[0].author
+    delete store.state.todos[0]
+
+    expect(isDetached(alice)).toBe(true)
+  })
 })


### PR DESCRIPTION
- Prevent re-renders on unmounted React components still bound to detached nodes of the store. This is mostly in React versions where `useSyncExternalStore` is not available and `@arborjs/react` resorts to `useState` for updates;
